### PR TITLE
Validate access using also an API key.

### DIFF
--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Configuration/ZapierSettings.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Configuration/ZapierSettings.cs
@@ -12,8 +12,12 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Configuration
         public ZapierSettings(NameValueCollection appSettings)
         {
             UserGroup = appSettings[Constants.UmbracoCmsIntegrationsAutomationZapierUserGroup];
+
+            ApiKey = appSettings[Constants.UmbracoCmsIntegrationsAutomationZapierApiKey];
         }
 
         public string UserGroup { get; set; }
+
+        public string ApiKey { get; set; }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Constants.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Constants.cs
@@ -11,11 +11,15 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier
 
         public const string UmbracoCmsIntegrationsAutomationZapierUserGroup = "Umbraco.Cms.Integrations.Automation.Zapier.UserGroup";
 
+        public const string UmbracoCmsIntegrationsAutomationZapierApiKey = "Umbraco.Cms.Integrations.Automation.Zapier.ApiKey";
+
         public static class ZapierAppConfiguration
         {
             public const string UsernameHeaderKey = "X-USERNAME";
 
             public const string PasswordHeaderKey = "X-PASSWORD";
+
+            public const string ApiKeyHeaderKey = "X-APIKEY";
         }
 
         public static class Configuration

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/AuthController.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/AuthController.cs
@@ -1,18 +1,15 @@
 ﻿using System.Threading.Tasks;
 
-using Umbraco.Cms.Integrations.Automation.Zapier.Configuration;
 using Umbraco.Cms.Integrations.Automation.Zapier.Models;
 using Umbraco.Cms.Integrations.Automation.Zapier.Services;
 
 #if NETCOREAPP
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
+
 using Umbraco.Cms.Web.Common.Controllers;
-using Umbraco.Cms.Core.Security;
 #else
 using System.Web.Http;
-using System.Configuration;
-using Umbraco.Cms.Integrations.Automation.Zapier.Models.Dtos;
+
 using Umbraco.Web.WebApi;
 #endif
 
@@ -23,31 +20,14 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Controllers
     /// </summary>
     public class AuthController : UmbracoApiController
     {
-        private readonly ZapierSettings Options;
-
         private readonly IUserValidationService _userValidationService;
 
-#if NETCOREAPP
-        private readonly IBackOfficeUserManager _backOfficeUserManager;
-
-        public AuthController(IBackOfficeUserManager backOfficeUserManager, IUserValidationService userValidationService, IOptions<ZapierSettings> options)
-        {
-            _backOfficeUserManager = backOfficeUserManager;
-            
-            _userValidationService = userValidationService;
-
-            Options = options.Value;
-        }
-#else
         public AuthController(IUserValidationService userValidationService)
         {
-            Options = new ZapierSettings(ConfigurationManager.AppSettings);
-
             _userValidationService = userValidationService;
         }
-#endif
 
         [HttpPost]
-        public async Task<bool> ValidateUser([FromBody] UserModel userModel) => await _userValidationService.Validate(userModel.Username, userModel.Password, Options.UserGroup);
+        public async Task<bool> ValidateUser([FromBody] UserModel userModel) => await _userValidationService.Validate(userModel.Username, userModel.Password, userModel.ApiKey);
     }
 }

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/ContentController.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/ContentController.cs
@@ -35,7 +35,7 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Controllers
 
         public IEnumerable<ContentTypeDto> GetContentTypes()
         {
-            if (!IsUserValid()) return null;
+            if (!IsAccessValid()) return null;
 
             var contentTypes = _contentTypeService.GetAll();
 

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/PollingController.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/PollingController.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Controllers
         [Obsolete("Used only for Umbraco Zapier app v1.0.0. For updated versions use GetContentByType")]
         public IEnumerable<PublishedContentDto> GetSampleContent()
         {
-            if (!IsUserValid()) return null;
+            if (!IsAccessValid()) return null;
 
             var rootNodes = _contentService.GetRootContent()
                 .Where(p => p.Published)
@@ -60,7 +60,7 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Controllers
 
         public List<Dictionary<string, string>> GetContentByType(string alias)
         {
-            if (!IsUserValid()) return null;
+            if (!IsAccessValid()) return null;
 
             var contentType = _contentTypeService.Get(alias);
             if (contentType == null) return new List<Dictionary<string, string>>();

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/SubscriptionController.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/SubscriptionController.cs
@@ -38,7 +38,7 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Controllers
         [HttpPost]
         public bool UpdatePreferences([FromBody] SubscriptionDto dto)
         {
-            if (!IsUserValid() || dto == null) return false;
+            if (!IsAccessValid() || dto == null) return false;
 
             var result = dto.SubscribeHook
                 ? _zapierSubscriptionHookService.Add(dto.EntityId, dto.Type, dto.HookUrl)

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/ZapierAuthorizedApiController.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/ZapierAuthorizedApiController.cs
@@ -36,10 +36,11 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Controllers
             _userValidationService = userValidationService;
         }
 
-        public bool IsUserValid()
+        public bool IsAccessValid()
         {
             string username = string.Empty;
             string password = string.Empty;
+            string apiKey = string.Empty;
 
 #if NETCOREAPP
             if (Request.Headers.TryGetValue(Constants.ZapierAppConfiguration.UsernameHeaderKey,
@@ -48,6 +49,9 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Controllers
             if (Request.Headers.TryGetValue(Constants.ZapierAppConfiguration.PasswordHeaderKey,
                     out var passwordValues))
                 password = passwordValues.First();
+            if (Request.Headers.TryGetValue(Constants.ZapierAppConfiguration.ApiKeyHeaderKey,
+                    out var apiKeyValues))
+                apiKey = apiKeyValues.First();
 #else
             if (Request.Headers.TryGetValues(Constants.ZapierAppConfiguration.UsernameHeaderKey,
                     out var usernameValues))
@@ -55,9 +59,15 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Controllers
             if (Request.Headers.TryGetValues(Constants.ZapierAppConfiguration.PasswordHeaderKey,
                     out var passwordValues))
                 password = passwordValues.First();
+            if (Request.Headers.TryGetValues(Constants.ZapierAppConfiguration.ApiKeyHeaderKey,
+                    out var apiKeyValues))
+                apiKey = apiKeyValues.First();
 #endif
 
-            if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password)) return false;
+            if (string.IsNullOrEmpty(apiKey) && (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))) return false;
+
+            if (!string.IsNullOrEmpty(apiKey))
+                return apiKey == Options.ApiKey;
 
             var isAuthorized = _userValidationService.Validate(username, password, Options.UserGroup).GetAwaiter()
                 .GetResult();

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Models/UserModel.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Models/UserModel.cs
@@ -6,5 +6,7 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Models
         public string Username { get; set; }
 
         public string Password { get; set; }
+
+        public string ApiKey { get; set; }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/IUserValidationService.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/IUserValidationService.cs
@@ -4,6 +4,6 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Services
 {
     public interface IUserValidationService
     {
-        Task<bool> Validate(string username, string password, string userGroup);
+        Task<bool> Validate(string username, string password, string apiKey);
     }
 }

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/UserValidationService.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/UserValidationService.cs
@@ -1,10 +1,16 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 
+using Umbraco.Cms.Integrations.Automation.Zapier.Configuration;
+
 #if NETCOREAPP
+using Microsoft.Extensions.Options;
+
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 #else
+using System.Configuration;
+
 using Umbraco.Core.Services;
 #endif
 
@@ -14,23 +20,38 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Services
     {
         private readonly IUserService _userService;
 
+        private readonly ZapierSettings _zapierSettings;
 
 #if NETCOREAPP
         private readonly IBackOfficeUserManager _backOfficeUserManager;
 
-        public UserValidationService(IBackOfficeUserManager backOfficeUserManager, IUserService userService)
+        public UserValidationService(IOptions<ZapierSettings> options, IBackOfficeUserManager backOfficeUserManager)
         {
             _backOfficeUserManager = backOfficeUserManager;
+
+            _zapierSettings = options.Value;
         }
 #else
         public UserValidationService(IUserService userService)
         {
             _userService = userService;
+
+            _zapierSettings = new ZapierSettings(ConfigurationManager.AppSettings);
         }
 #endif
 
-        public async Task<bool> Validate(string username, string password, string userGroup)
+        /// <summary>
+        /// Allow access by validating API Key. If API key is missing, validate user credentials.
+        /// </summary>
+        /// <param name="username"></param>
+        /// <param name="password"></param>
+        /// <param name="apiKey"></param>
+        /// <returns></returns>
+        public async Task<bool> Validate(string username, string password, string apiKey)
         {
+            if (!string.IsNullOrEmpty(apiKey))
+                return apiKey == _zapierSettings.ApiKey;
+
 #if NETCOREAPP
             var isUserValid =
                 await _backOfficeUserManager.ValidateCredentialsAsync(username, password);
@@ -40,11 +61,11 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Services
 
             if (!isUserValid) return false;
 
-            if (!string.IsNullOrEmpty(userGroup))
+            if (!string.IsNullOrEmpty(_zapierSettings.UserGroup))
             {
                 var user = _userService.GetByUsername(username);
 
-                return user != null && user.Groups.Any(p => p.Name == userGroup);
+                return user != null && user.Groups.Any(p => p.Name == _zapierSettings.UserGroup);
             }
 
             return true;


### PR DESCRIPTION
Additional feature to control platform access through an API key.

Use cases:

1. User tries to authenticate when a Zap trigger is created: if an API key is provided in the POST request, the access is validated by comparing the request value with an API key value saved in the configuration file of the website; otherwise, the access validation takes into consideration the user credentials.
2. Polling and Subscribe actions are called: the same validation process as above runs.

