### PR TITLE
Issue #31 - return product id

### DIFF
--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
@@ -56,6 +56,7 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Editors
                 where ids.Contains(p.Id)
                 select new ProductViewModel
                 {
+                    Id = p.Id,
                     Title = p.Title,
                     Body = p.Body,
                     Image = p.Image.Src

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/ViewModels/ProductViewModel.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/ViewModels/ProductViewModel.cs
@@ -3,6 +3,8 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Models.ViewModels
 {
     public class ProductViewModel
     {
+        public long Id { get; set; }
+
         public string Title { get; set; }
 
         public string Body { get; set; }


### PR DESCRIPTION
This PR handles the issue reported [here](https://github.com/umbraco/Umbraco.Cms.Integrations/issues/31), returning the Shopify product id with the view model.