### PR TITLE
Fix asynchronous calls to Shopify in value converter and version update.

### DIFF
--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading.Tasks;
 using Umbraco.Cms.Integrations.Commerce.Shopify.Models.ViewModels;
 using Umbraco.Cms.Integrations.Commerce.Shopify.Services;
 
@@ -50,7 +50,9 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Editors
 
             var ids = (long[]) inter;
 
-            var result = _apiService.GetResults().GetAwaiter().GetResult();
+            var t = Task.Run(async () => await _apiService.GetResults());
+
+            var result = t.Result;
 
             var products = from p in result.Result.Products
                 where ids.Contains(p.Id)

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Umbraco.Cms.Integrations.Commerce.Shopify.csproj
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Umbraco.Cms.Integrations.Commerce.Shopify.csproj
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.0.1</Version>
+		<Version>1.0.2</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 	</PropertyGroup>

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/package.xml
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/package.xml
@@ -3,7 +3,7 @@
   <info>
     <package>
       <name>Umbraco.Cms.Integrations.Commerce.Shopify</name>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
       <iconUrl></iconUrl>
       <licence url="https://opensource.org/licenses/MIT">MIT</licence>
       <url>https://github.com/umbraco/Umbraco.Cms.Integrations</url>


### PR DESCRIPTION
- Update the value converter to handle asynchronous calls differently. While rendering the list of products, the thread querying the products from Shopify based on the saved IDs didn't complete and was left hanging.
- Update version to 1.0.2