### PR TITLE
acoumb

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/formpicker.controller.js
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/formpicker.controller.js
@@ -10,6 +10,7 @@
             vm.searchTerm = "";
             vm.error = "";
             vm.isValid = true;
+            vm.isConnected = false;
 
             // check configuration
             checkConfiguration(loadForms);
@@ -65,6 +66,7 @@
                 if (vm.status.useOAuth === true) {
                     // use OAuth
                     umbracoCmsIntegrationsCrmHubspotResource.validateAccessToken().then(function (response) {
+                        
                         if (response.isExpired === true || response.isValid === false) {
                             vm.loading = false;
                             notificationsService.warning("HubSpot API", "Unable to connect to HubSpot. Please review the settings of the form picker property's data type.");
@@ -77,7 +79,8 @@
 
                             if (data.isValid === false || data.isExpired === true) {
                                 notificationsService.error("HubSpot API", "Unable to retrieve the list of forms from HubSpot. Please review the settings of the form picker property's data type.");
-                            }
+                            } else
+                                vm.isConnected = true;
                         });
                     });
                 } else {
@@ -89,9 +92,20 @@
 
                         if (data.isValid === false || data.isExpired === true) {
                             notificationsService.error("HubSpot API", "Invalid API key");
-                        }
+                        } else
+                            vm.isConnected = true;
                     });
 
                 }
             }
+
+            $scope.connected = function () {
+                vm.isConnected = true;
+                loadForms();
+            };
+
+            $scope.revoked = function () {
+                vm.isConnected = false;
+                vm.hubspotFormsList = [];
+            };
         });

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/hubspotauthorization.directive.js
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/hubspotauthorization.directive.js
@@ -1,0 +1,11 @@
+﻿angular.module("umbraco.directives")
+    .directive("hubspotAuthorization", function () {
+        return {
+            restrict: "E",
+            scope: {
+                "connected": "&onConnected",
+                "revoked": "&onRevoked"
+            },
+            templateUrl: "/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/views/settings.html"
+        }
+    });

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/settings.controller.js
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/settings.controller.js
@@ -29,8 +29,11 @@
             }
 
             if (response.isValid !== true) {
-                notificationsService.warning("HubSpot Configuration",
-                    "Invalid setup. Please review the API/OAuth settings.");
+                // if directive runs from property editor, the notifications should be hidden, because they will not be displayed properly behind the overlay window.
+                // if directive runs from data type, the notifications are displayed
+                if (typeof $scope.connected === "undefined")
+                    notificationsService.warning("HubSpot Configuration",
+                        "Invalid setup. Please review the API/OAuth settings.");
             }
         });
 
@@ -46,7 +49,12 @@
     vm.onRevokeToken = function() {
         umbracoCmsIntegrationsCrmHubspotResource.revokeAccessToken().then(function (response) {
             vm.oauthSetup.isConnected = false;
-            notificationsService.success("HubSpot Configuration", "OAuth connection revoked.");
+
+            if(typeof $scope.connected === "undefined")
+                notificationsService.success("HubSpot Configuration", "OAuth connection revoked.");
+
+            if (typeof $scope.revoked === "function")
+                $scope.revoked();
         });
     }
 
@@ -56,11 +64,17 @@
 
             umbracoCmsIntegrationsCrmHubspotResource.getAccessToken(event.data.code).then(function (response) {
                 if (response.startsWith("Error:")) {
-                    notificationsService.error("HubSpot Configuration", response);
+                    if (typeof $scope.connected === "undefined")
+                        notificationsService.error("HubSpot Configuration", response);
                 } else {
                     vm.oauthSetup.isConnected = true;
                     vm.status.description = umbracoCmsIntegrationsCrmHubspotService.configDescription.OAuthConnected;
-                    notificationsService.success("HubSpot Configuration", "OAuth connected.");
+
+                    if (typeof $scope.connected === "undefined")
+                        notificationsService.success("HubSpot Configuration", "OAuth connected.");
+
+                    if (typeof $scope.connected === "function")
+                        $scope.connected();
                 }
             });
 

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/package.manifest
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/package.manifest
@@ -3,7 +3,8 @@
     "~/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/formpicker.controller.js",
     "~/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/settings.controller.js",
     "~/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/hubspot.resource.js",
-    "~/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/hubspot.service.js"
+    "~/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/hubspot.service.js",
+    "~/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/hubspotauthorization.directive.js"
   ],
   "css": [
     "~/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/css/styles.css"

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/views/formpickereditor.html
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/views/formpickereditor.html
@@ -4,13 +4,13 @@
             <umb-box>
                 <umb-box-header title="{{ model.title }}" description="{{ model.subtitle }}"></umb-box-header>
                 <umb-box-content>
-                    <div class="hsOverlayGroup">
+                    <div class="hsOverlayGroup" ng-if="vm.isConnected">
                         <div class="form-search">
                             <i class="icon-search"></i>
                             <input type="text" class="-full-width-input" ng-model="vm.searchTerm" placeholder="Type to search..." umb-auto-focus="" aria-invalid="false">
                         </div>
                     </div>
-                    <div class="hsOverlayGroup">
+                    <div class="hsOverlayGroup" ng-if="vm.isConnected">
                         <ul class="hsFormsList">
                             <li ng-repeat="form in vm.hubspotFormsList | orderBy:'name' | filter:vm.searchTerm" ng-click="model.pickForm(form)" class="ng-scope" role="button" tabindex="0">
                                 <a href="" ng-attr-title="form.name">
@@ -20,6 +20,14 @@
                                 </a>
                             </li>
                         </ul>
+                    </div>
+                </umb-box-content>
+            </umb-box>
+            <umb-box>
+                <umb-box-header title="HubSpot API" description="Please connect to HubSpot."></umb-box-header>
+                <umb-box-content>
+                    <div class="hsOverlayGroup">
+                        <hubspot-authorization on-connected="connected()" on-revoked="revoked()"></hubspot-authorization>
                     </div>
                 </umb-box-content>
             </umb-box>

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.0.2</Version>
+		<Version>1.1.2</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 	</PropertyGroup>
@@ -41,6 +41,10 @@
 			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
 			<CopyToPublishDirectory>Always</CopyToPublishDirectory>
 		</Content>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <None Remove="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\js\hubspotauthorization.directive.js" />
 	</ItemGroup>
 
 	<Target Name="RemoveLuceneAnalyzer" BeforeTargets="CoreCompile">

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/package.xml
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/package.xml
@@ -3,7 +3,7 @@
   <info>
     <package>
       <name>Umbraco.Cms.Integrations.Crm.Hubspot</name>
-      <version>1.0.2</version>
+      <version>1.1.2</version>
       <iconUrl></iconUrl>
       <licence url="https://opensource.org/licenses/MIT">MIT</licence>
       <url>https://github.com/umbraco/Umbraco.Cms.Integrations</url>


### PR DESCRIPTION
This PR handles the issue reported [here](https://github.com/umbraco/Umbraco.Cms.Integrations/issues/30) and allows editors to control OAuth access from the property editor also, not just from the data type, using a custom implemented directive.