### PR TITLE
Fix succes event handled multiple times

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/settings.controller.js
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/settings.controller.js
@@ -4,7 +4,9 @@
 
     const oauthName = "OAuth";
 
-    vm.oauthSetup = {};
+    vm.oauthSetup = {
+        authEventHandled : 0
+    };
     vm.status = {};
 
     $scope.$on('formSubmitting', function () {
@@ -49,6 +51,7 @@
     vm.onRevokeToken = function() {
         umbracoCmsIntegrationsCrmHubspotResource.revokeAccessToken().then(function (response) {
             vm.oauthSetup.isConnected = false;
+            vm.oauthSetup.authEventHandled = 0;
 
             if(typeof $scope.connected === "undefined")
                 notificationsService.success("HubSpot Configuration", "OAuth connection revoked.");
@@ -60,9 +63,15 @@
 
     // authorization listener
     window.addEventListener("message", function (event) {
+
         if (event.data.type === "hubspot:oauth:success") {
 
+            if (vm.oauthSetup.authEventHandled != 0) return;
+
             umbracoCmsIntegrationsCrmHubspotResource.getAccessToken(event.data.code).then(function (response) {
+
+                vm.oauthSetup.authEventHandled = 1;
+
                 if (response.startsWith("Error:")) {
                     if (typeof $scope.connected === "undefined")
                         notificationsService.error("HubSpot Configuration", response);

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/settings.controller.js
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/settings.controller.js
@@ -5,7 +5,7 @@
     const oauthName = "OAuth";
 
     vm.oauthSetup = {
-        authEventHandled : 0
+        authEventHandled : false
     };
     vm.status = {};
 
@@ -51,7 +51,7 @@
     vm.onRevokeToken = function() {
         umbracoCmsIntegrationsCrmHubspotResource.revokeAccessToken().then(function (response) {
             vm.oauthSetup.isConnected = false;
-            vm.oauthSetup.authEventHandled = 0;
+            vm.oauthSetup.authEventHandled = false;
 
             if(typeof $scope.connected === "undefined")
                 notificationsService.success("HubSpot Configuration", "OAuth connection revoked.");
@@ -66,11 +66,11 @@
 
         if (event.data.type === "hubspot:oauth:success") {
 
-            if (vm.oauthSetup.authEventHandled != 0) return;
+            if (vm.oauthSetup.authEventHandled === true) return;
 
             umbracoCmsIntegrationsCrmHubspotResource.getAccessToken(event.data.code).then(function (response) {
 
-                vm.oauthSetup.authEventHandled = 1;
+                vm.oauthSetup.authEventHandled = true;
 
                 if (response.startsWith("Error:")) {
                     if (typeof $scope.connected === "undefined")


### PR DESCRIPTION
This PR fixes an issue when handling the OAuth success event: while in the property editor, the event is raised two times - first request with the authorization code returns the access token from HubSpot API; second request with the same authorization code will return a _Bad Request_ from HubSpot.

From a UI perspective, the only impact is that shortly after the access token is received, an error notification will be returned.