### PR TITLE
Use cases updates

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/App_Plugins/UmbracoCms.Integrations/Crm/Dynamics/js/formpicker.controller.js
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/App_Plugins/UmbracoCms.Integrations/Crm/Dynamics/js/formpicker.controller.js
@@ -79,8 +79,8 @@
                     });
                 });
             }
+            vm.loading = false;
         });
-        vm.loading = false;
     }
 
     $scope.connected = function () {

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/App_Plugins/UmbracoCms.Integrations/Crm/Dynamics/js/formpicker.controller.js
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/App_Plugins/UmbracoCms.Integrations/Crm/Dynamics/js/formpicker.controller.js
@@ -3,13 +3,9 @@
     var vm = this;
 
     vm.loading = false;
-    vm.dynamicsFormsList = [];
-
     vm.searchTerm = "";
-
     vm.selectedForm = {};
     vm.iframeEmbedded = false;
-
     vm.isConnected = false;
 
     umbracoCmsIntegrationsCrmDynamicsResource.checkOAuthConfiguration().then(function (response) {
@@ -25,6 +21,10 @@
     vm.saveForm = function (form) {
 
         umbracoCmsIntegrationsCrmDynamicsResource.getEmbedCode(form.id).then(function (response) {
+
+            if (response.length == 0) {
+                notificationsService.warning("Dynamics API", "Unable to embed selected form. Please check if it is live.");
+            }
 
             form.embedCode = response;
 
@@ -49,9 +49,11 @@
             size: "medium",
             selectForm: function (form, iframeEmbedded) {
 
-                form.iframeEmbedded = iframeEmbedded;
+                if (form.id !== undefined) {
+                    form.iframeEmbedded = iframeEmbedded;
 
-                vm.saveForm(form);
+                    vm.saveForm(form);
+                }
 
                 editorService.close();
             },
@@ -64,8 +66,9 @@
     };
 
     function loadForms() {
-        vm.dynamicsFormsList = [];
+        vm.loading = true;
         umbracoCmsIntegrationsCrmDynamicsResource.getForms().then(function (response) {
+            vm.dynamicsFormsList = [];
             if (response) {
                 response.value.forEach(item => {
                     vm.dynamicsFormsList.push({
@@ -77,6 +80,7 @@
                 });
             }
         });
+        vm.loading = false;
     }
 
     $scope.connected = function () {

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Services/DynamicsService.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Services/DynamicsService.cs
@@ -89,7 +89,7 @@ namespace Umbraco.Cms.Integrations.Crm.Dynamics.Services
 
             var embedCode = JsonConvert.DeserializeObject<ResponseDto<FormDto>>(result);
 
-            return embedCode.Value.First().EmbedCode;
+            return embedCode.Value.FirstOrDefault() != null ? embedCode.Value.First().EmbedCode : string.Empty;
         }
 
         private async Task<string> GetUserId(string accessToken)


### PR DESCRIPTION
Current PR fixes a couple of use cases that create inconsistencies in the normal workflow of the Dynamics extension:

1. Forms array contains duplicates as the push action is managed twice.
2. If a form is not live in one Dynamics instance, an exception was thrown with not too much information for the user. Now a warning message will be prompted to the editor, notifying him that he should revise the form status.