### PR TITLE
Handle oauth success event raised multiple times

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/App_Plugins/UmbracoCms.Integrations/Crm/Dynamics/js/configuration.controller.js
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/App_Plugins/UmbracoCms.Integrations/Crm/Dynamics/js/configuration.controller.js
@@ -2,6 +2,7 @@
     var vm = this;
 
     vm.oauthConfig = {};
+    vm.oauthSuccessEventCount = 0;
 
     umbracoCmsIntegrationsCrmDynamicsResource.checkOAuthConfiguration().then(function (response) {
         if (response && response.isAuthorized) {
@@ -39,30 +40,34 @@
     // authorization listener
     window.addEventListener("message", function (event) {
         if (event.data.type === "hubspot:oauth:success") {
+            vm.oauthSuccessEventCount += 1;
+            
+            if (vm.oauthSuccessEventCount == 1) {
+                umbracoCmsIntegrationsCrmDynamicsResource.getAccessToken(event.data.code).then(function (response) {
 
-            umbracoCmsIntegrationsCrmDynamicsResource.getAccessToken(event.data.code).then(function (response) {
-                if (response.startsWith("Error:")) {
+                    if (response.startsWith("Error:")) {
 
-                    // if directive runs from property editor, the notifications should be hidden, because they will not be displayed properly behind the overlay window.
-                    // if directive runs from data type, the notifications are displayed
-                    if (typeof $scope.connected === "undefined")
-                        notificationsService.error("Dynamics Configuration", response);
-                } else {
-                    vm.oauthConfig.isConnected = true;
+                        // if directive runs from property editor, the notifications should be hidden, because they will not be displayed properly behind the overlay window.
+                        // if directive runs from data type, the notifications are displayed
+                        if (typeof $scope.connected === "undefined")
+                            notificationsService.error("Dynamics Configuration", response);
+                    } else {
+                        vm.oauthConfig.isConnected = true;
 
-                    // if directive runs from property editor, the notifications should be hidden, because they will not be displayed properly behind the overlay window.
-                    // if directive runs from data type, the notifications are displayed
-                    if (typeof $scope.connected === "undefined")
-                        notificationsService.success("Dynamics Configuration", "OAuth connected.");
+                        // if directive runs from property editor, the notifications should be hidden, because they will not be displayed properly behind the overlay window.
+                        // if directive runs from data type, the notifications are displayed
+                        if (typeof $scope.connected === "undefined")
+                            notificationsService.success("Dynamics Configuration", "OAuth connected.");
 
-                    umbracoCmsIntegrationsCrmDynamicsResource.getSystemUserFullName().then(function(response) {
-                        vm.oauthConfig.fullName = response;
-                    });
+                        umbracoCmsIntegrationsCrmDynamicsResource.getSystemUserFullName().then(function (response) {
+                            vm.oauthConfig.fullName = response;
+                        });
 
-                    if (typeof $scope.connected === "function")
-                        $scope.connected();
-                }
-            });
+                        if (typeof $scope.connected === "function")
+                            $scope.connected();
+                    }
+                });
+            }
         }
     }, false);
 }

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Controllers/FormsController.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Controllers/FormsController.cs
@@ -124,7 +124,7 @@ namespace Umbraco.Cms.Integrations.Crm.Dynamics.Controllers
                 var errorResult = await response.Content.ReadAsStringAsync();
                 var errorDto = JsonConvert.DeserializeObject<ErrorDto>(errorResult);
 
-                return "Error: " + errorDto.Message;
+                return "Error: " + errorDto.ErrorDescription;
             }
 
             return "Error: An unexpected error occurred.";

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Models/Dtos/ErrorDto.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Models/Dtos/ErrorDto.cs
@@ -9,5 +9,8 @@ namespace Umbraco.Cms.Integrations.Crm.Dynamics.Models.Dtos
 
         [JsonProperty("message")]
         public string Message { get; set; }
+
+        [JsonProperty("error_description")]
+        public string ErrorDescription { get; set; }
     }
 }


### PR DESCRIPTION
PR for fixing the following use case:

- user connects for the first time -> success
- user revokes and saves the page content
- user re-connects and the 0auth success events is raised 2 times, causing Microsoft API to throw an exception because the authorization code has been already granted permissions. As a result, a UI error message is show and then a success one, and the status is not updated properly.