### PR TITLE
Render view exclusion; Use constants for picker properties.

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Constants.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Constants.cs
@@ -6,6 +6,8 @@
 
     public static class Constants
     {
+        public const string PropertyEditorAlias = "Umbraco.Cms.Integrations.Crm.Hubspot.FormPicker";
+
         public const string UmbracoCmsIntegrationsCrmHubspotApiKey = "Umbraco.Cms.Integrations.Crm.Hubspot.ApiKey";
 
         public const string UmbracoCmsIntegrationsCrmHubspotRegion = "Umbraco.Cms.Integrations.Crm.Hubspot.Region";

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Editors/FormPickerValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Editors/FormPickerValueConverter.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Editors
 {
     public class FormPickerValueConverter : PropertyValueConverterBase
     {
-        public override bool IsConverter(IPublishedPropertyType propertyType) => propertyType.EditorAlias.Equals("Umbraco.Cms.Integrations.Crm.Hubspot.FormPicker");
+        public override bool IsConverter(IPublishedPropertyType propertyType) => propertyType.EditorAlias.Equals(Constants.PropertyEditorAlias);
 
         public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Snapshot;
 

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/HubspotFormPickerPropertyEditor.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/HubspotFormPickerPropertyEditor.cs
@@ -1,4 +1,5 @@
 ﻿#if NETCOREAPP
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.PropertyEditors;
 #else
@@ -9,10 +10,10 @@ using Umbraco.Core.PropertyEditors;
 namespace Umbraco.Cms.Integrations.Crm.Hubspot
 {
     [DataEditor(
-        alias: "Umbraco.Cms.Integrations.Crm.Hubspot.FormPicker",
+        alias: Constants.PropertyEditorAlias,
         name: "HubSpot Form Picker",
         view: "~/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/views/formpicker.html",
-        Group = "Pickers",
+        Group = Core.Constants.PropertyEditors.Groups.Pickers,
         Icon = "icon-handshake"
         )]
     public class HubspotFormPickerPropertyEditor: DataEditor

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.1.2</Version>
+		<Version>1.1.3</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 	</PropertyGroup>

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/build/Umbraco.Cms.Integrations.Crm.Hubspot.targets
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/build/Umbraco.Cms.Integrations.Crm.Hubspot.targets
@@ -14,7 +14,12 @@
 		<Copy SourceFiles="@(HubspotPropertyEditorFiles)"
 		      DestinationFiles="@(HubspotPropertyEditorFiles->'$(MSBuildProjectDirectory)\App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\%(RecursiveDir)%(Filename)%(Extension)')"
 		      SkipUnchangedFiles="true" />
-
+	</Target>
+	
+	<Target Name="ClearHubspotRenderingView" 
+			Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0'" BeforeTargets="Build">
+		<Message Text="Delete Umbraco 8 rendering view" Importance="high" />
+		<Delete Files="$(MSBuildProjectDirectory)\App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\Render\HubspotForm.cshtml"/>
 	</Target>
 
 	<Target Name="ClearHubspotPropertyEditorAssets" BeforeTargets="Clean">

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/package.xml
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/package.xml
@@ -3,7 +3,7 @@
   <info>
     <package>
       <name>Umbraco.Cms.Integrations.Crm.Hubspot</name>
-      <version>1.1.2</version>
+      <version>1.1.3</version>
       <iconUrl></iconUrl>
       <licence url="https://opensource.org/licenses/MIT">MIT</licence>
       <url>https://github.com/umbraco/Umbraco.Cms.Integrations</url>


### PR DESCRIPTION
This PR handles the issues reported here:

1. [#46](https://github.com/umbraco/Umbraco.Cms.Integrations/issues/46) : exclude rendering view for Umbraco 8 
2. [#48](https://github.com/umbraco/Umbraco.Cms.Integrations/issues/48) : use constants 
