### PR TITLE
Validate users outside organisation; HTTP revoke action update.

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/App_Plugins/UmbracoCms.Integrations/Crm/Dynamics/js/configuration.controller.js
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/App_Plugins/UmbracoCms.Integrations/Crm/Dynamics/js/configuration.controller.js
@@ -11,6 +11,9 @@
 
             if (typeof $scope.connected === "function")
                 $scope.connected();
+        } else if (response.message.length > 0) {
+            if (typeof $scope.connected === "undefined")
+                notificationsService.error("Dynamics Configuration", response.message);
         }
     });
 
@@ -41,7 +44,7 @@
     window.addEventListener("message", function (event) {
         if (event.data.type === "hubspot:oauth:success") {
             vm.oauthSuccessEventCount += 1;
-            
+
             if (vm.oauthSuccessEventCount == 1) {
                 umbracoCmsIntegrationsCrmDynamicsResource.getAccessToken(event.data.code).then(function (response) {
 

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/App_Plugins/UmbracoCms.Integrations/Crm/Dynamics/js/dynamics.resource.js
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/App_Plugins/UmbracoCms.Integrations/Crm/Dynamics/js/dynamics.resource.js
@@ -16,7 +16,7 @@
             },
             revokeAccessToken: function () {
                 return umbRequestHelper.resourcePromise(
-                    $http.post(`${apiEndpoint}/RevokeAccessToken`),
+                    $http.delete(`${apiEndpoint}/RevokeAccessToken`),
                     "Failed");
             },
             getSystemUserFullName: function () {

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Models/Dtos/ErrorDto.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Models/Dtos/ErrorDto.cs
@@ -7,6 +7,9 @@ namespace Umbraco.Cms.Integrations.Crm.Dynamics.Models.Dtos
         [JsonProperty("status")]
         public string Status { get; set; }
 
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
         [JsonProperty("message")]
         public string Message { get; set; }
 

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Models/Dtos/IdentityDto.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Models/Dtos/IdentityDto.cs
@@ -4,12 +4,14 @@ namespace Umbraco.Cms.Integrations.Crm.Dynamics.Models.Dtos
 {
     public class IdentityDto
     {
-        public bool IsAuthorized { get; set; } = true;
+        public bool IsAuthorized { get; set; }
 
         [JsonProperty("systemuserid")]
         public string UserId { get; set; }
 
         [JsonProperty("fullname")]
         public string FullName { get; set; }
+
+        public ErrorDto Error { get; set; }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Models/Dtos/OAuthConfigurationDto.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Models/Dtos/OAuthConfigurationDto.cs
@@ -19,5 +19,8 @@ namespace Umbraco.Cms.Integrations.Crm.Dynamics.Models.Dtos
 
         [JsonProperty("isAuthorized")]
         public bool IsAuthorized { get; set; }
+
+        [JsonProperty("message")]
+        public string Message { get; set; }
     }
 }


### PR DESCRIPTION
Updates included in this PR cover the issue described [here](https://github.com/umbraco/Umbraco.Cms.Integrations/issues/50):

- exception thrown when user is authenticated. An use case when this can be replicated is when an account outside the organization tries to authenticate, then an empty string is sent to the Microsoft API to retrieve user details, at which point the exception is thrown. Added validation to check and display an error message to the user if this occurs.
- _Revoke_ action throws a _400 Bad Request_ error on the POST action, so I changed it to a DELETE Http method.