### PR TITLE
Get URL for media content types

### DIFF
--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Constants.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Constants.cs
@@ -42,12 +42,5 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier
 
             public const int Form = 2;
         }
-
-        public static class MediaAliases
-        {
-            public const string UmbracoMediaPicker = "Umbraco.MediaPicker";
-
-            public const string UmbracoMediaPicker3 = "Umbraco.MediaPicker3";
-        }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Constants.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Constants.cs
@@ -42,5 +42,12 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier
 
             public const int Form = 2;
         }
+
+        public static class MediaAliases
+        {
+            public const string UmbracoMediaPicker = "Umbraco.MediaPicker";
+
+            public const string UmbracoMediaPicker3 = "Umbraco.MediaPicker3";
+        }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Extensions/ContentExtensions.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Extensions/ContentExtensions.cs
@@ -9,6 +9,7 @@ using Umbraco.Extensions;
 #else
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Web;
 #endif
 
 namespace Umbraco.Cms.Integrations.Automation.Zapier.Extensions
@@ -62,17 +63,13 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Extensions
 
         private static bool IsMedia(IPublishedProperty contentProperty, out string url)
         {
-            switch(contentProperty.PropertyType.EditorAlias)
+            switch (contentProperty.PropertyType.EditorAlias)
             {
-                case Constants.MediaAliases.UmbracoMediaPicker:
+                case Core.Constants.PropertyEditors.Aliases.MediaPicker:
                     var mediaPickerValue = contentProperty.GetValue() as IPublishedContent;
-#if NETCOREAPP
                     url = mediaPickerValue.Url();
-#else
-                    url = mediaPickerValue.Url;
-#endif
                     return true;
-                case Constants.MediaAliases.UmbracoMediaPicker3:
+                case Core.Constants.PropertyEditors.Aliases.MediaPicker3:
                     var mediaPicker3Value = contentProperty.GetValue() as MediaWithCrops;
                     url = mediaPicker3Value.LocalCrops.Src;
                     return true;

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Umbraco.Cms.Integrations.Automation.Zapier.csproj
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Umbraco.Cms.Integrations.Automation.Zapier.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="UmbracoCms.Web" Version="8.5.4" />
+	  <PackageReference Include="UmbracoCms.Core" Version="8.14.1" />
   </ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net50'">

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Umbraco.Cms.Integrations.Automation.Zapier.csproj
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Umbraco.Cms.Integrations.Automation.Zapier.csproj
@@ -9,13 +9,12 @@
     <RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
     <PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Automation.Zapier</PackageProjectUrl>
     <Product>Umbraco.Cms.Integrations.Automation.Zapier</Product>
-	<Version>1.0.4</Version>
+	<Version>1.1.0</Version>
 	<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="UmbracoCms.Web" Version="8.5.4" />
-	  <PackageReference Include="UmbracoCms.Core" Version="8.14.1" />
+    <PackageReference Include="UmbracoCms.Web" Version="8.14.0" />
   </ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net50'">

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/package.xml
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/package.xml
@@ -3,7 +3,7 @@
   <info>
     <package>
       <name>Umbraco.Cms.Integrations.Automation.Zapier</name>
-      <version>1.0.4</version>
+      <version>1.1.0</version>
       <iconUrl></iconUrl>
       <licence url="https://opensource.org/licenses/MIT">MIT</licence>
       <url>https://github.com/umbraco/Umbraco.Cms.Integrations</url>


### PR DESCRIPTION
This PR handles an issue reported [here](https://github.com/umbraco/Umbraco.Cms.Integrations/issues/47) for media pickers, when the string representation of the object was returned on polling.
With this update I've took into consideration the two media pickers with aliases: _Umbraco.MediaPicker3_ and _Umbraco.MediaPicker_(legacy).

Because the package requires a minimum version of 8.5.4, I've moved the constants locally, as _MediaPicker3_ was introduced with 8.14.0 and could not access it directly from _Umbraco.Core.Constants.PropertyEditors.Aliases.MediaPicker_.