### PR TITLE
Umbraco 11 test site; Hubspot - fix compatibility issue and update targeting frameworks

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/HubspotComposer.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/HubspotComposer.cs
@@ -13,7 +13,7 @@ using Umbraco.Core.Composing;
 
 namespace Umbraco.Cms.Integrations.Crm.Hubspot
 {
-    public class HubspotComposer : IUserComposer
+    public class HubspotComposer : IComposer
     {
 #if NETCOREAPP
         public void Compose(IUmbracoBuilder builder)

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
@@ -28,9 +28,9 @@
 	</ItemGroup>
 	
 	<ItemGroup Condition="'$(TargetFramework)' == 'net60'">
-		<PackageReference Include="Umbraco.Cms.Web.Website" version="[10.0.0,12)" />
-		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[10.0.0,12)" />
-		<PackageReference Include="Umbraco.Cms.Web.Common" version="[10.0.0,12)" />
+		<PackageReference Include="Umbraco.Cms.Web.Website" version="[10.0.0,11)" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[10.0.0,11)" />
+		<PackageReference Include="Umbraco.Cms.Web.Common" version="[10.0.0,11)" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net70'">

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net472;net50</TargetFrameworks>
+		<TargetFrameworks>net472;net50;net60;net70</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Crm.Hubspot</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.1.5</Version>
+		<Version>1.1.6</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
@@ -18,13 +18,25 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-		<PackageReference Include="UmbracoCms.Web" version="8.4.0" />
+		<PackageReference Include="UmbracoCms.Web" version="[8.4.0, 9)" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net50'">
-		<PackageReference Include="Umbraco.Cms.Web.Website" version="9.0.1" />
-		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="9.0.1" />
-		<PackageReference Include="Umbraco.Cms.Web.Common" version="9.0.1" />
+		<PackageReference Include="Umbraco.Cms.Web.Website" version="[9.0.1,10)" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[9.0.1,10)" />
+		<PackageReference Include="Umbraco.Cms.Web.Common" version="[9.0.1,10)" />
+	</ItemGroup>
+	
+	<ItemGroup Condition="'$(TargetFramework)' == 'net60'">
+		<PackageReference Include="Umbraco.Cms.Web.Website" version="[10.0.0,12)" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[10.0.0,12)" />
+		<PackageReference Include="Umbraco.Cms.Web.Common" version="[10.0.0,12)" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net70'">
+		<PackageReference Include="Umbraco.Cms.Web.Website" version="[11.0.0,12)" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[11.0.0,12)" />
+		<PackageReference Include="Umbraco.Cms.Web.Common" version="[11.0.0,12)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Umbraco.Cms.Integrations.Testsite.V11/Program.cs
+++ b/src/Umbraco.Cms.Integrations.Testsite.V11/Program.cs
@@ -1,0 +1,26 @@
+namespace Umbraco.Cms.Integrations.Testsite.V11
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+            => CreateHostBuilder(args)
+                .Build()
+                .Run();
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+#if DEBUG
+            .ConfigureAppConfiguration(config => 
+                config.AddJsonFile(
+                    "appsettings.Local.json",
+                    optional: true,
+                    reloadOnChange: true))
+#endif
+                .ConfigureUmbracoDefaults()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStaticWebAssets();
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Testsite.V11/Properties/launchSettings.json
+++ b/src/Umbraco.Cms.Integrations.Testsite.V11/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:15123",
+      "sslPort": 44321
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Umbraco.Web.UI": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:44321;http://localhost:15123",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }      
+    }
+  }
+}

--- a/src/Umbraco.Cms.Integrations.Testsite.V11/Startup.cs
+++ b/src/Umbraco.Cms.Integrations.Testsite.V11/Startup.cs
@@ -1,0 +1,65 @@
+namespace Umbraco.Cms.Integrations.Testsite.V11
+{
+    public class Startup
+    {
+        private readonly IWebHostEnvironment _env;
+        private readonly IConfiguration _config;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Startup" /> class.
+        /// </summary>
+        /// <param name="webHostEnvironment">The web hosting environment.</param>
+        /// <param name="config">The configuration.</param>
+        /// <remarks>
+        /// Only a few services are possible to be injected here https://github.com/dotnet/aspnetcore/issues/9337.
+        /// </remarks>
+        public Startup(IWebHostEnvironment webHostEnvironment, IConfiguration config)
+        {
+            _env = webHostEnvironment ?? throw new ArgumentNullException(nameof(webHostEnvironment));
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+        }
+
+        /// <summary>
+        /// Configures the services.
+        /// </summary>
+        /// <param name="services">The services.</param>
+        /// <remarks>
+        /// This method gets called by the runtime. Use this method to add services to the container.
+        /// For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940.
+        /// </remarks>
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddUmbraco(_env, _config)
+                .AddBackOffice()
+                .AddWebsite()
+                .AddComposers()
+                .Build();
+        }
+
+        /// <summary>
+        /// Configures the application.
+        /// </summary>
+        /// <param name="app">The application builder.</param>
+        /// <param name="env">The web hosting environment.</param>
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseUmbraco()
+                .WithMiddleware(u =>
+                {
+                    u.UseBackOffice();
+                    u.UseWebsite();
+                })
+                .WithEndpoints(u =>
+                {
+                    u.UseInstallerEndpoints();
+                    u.UseBackOfficeEndpoints();
+                    u.UseWebsiteEndpoints();
+                });
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Testsite.V11/Umbraco.Cms.Integrations.Testsite.V11.csproj
+++ b/src/Umbraco.Cms.Integrations.Testsite.V11/Umbraco.Cms.Integrations.Testsite.V11.csproj
@@ -1,0 +1,80 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\css\styles.css">
+      <PackagePath>App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\js\formpicker.controller.js">
+      <PackagePath>App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\js\hubspot.resource.js">
+      <PackagePath>App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\js\hubspot.service.js">
+      <PackagePath>App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\js\hubspotauthorization.directive.js">
+      <PackagePath>App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\js\settings.controller.js">
+      <PackagePath>App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\package.manifest">
+      <PackagePath>App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\Render\HubspotForm.cshtml">
+      <PackagePath>App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\Render\HubspotFormV9.cshtml">
+      <PackagePath>App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\views\formpicker.html">
+      <PackagePath>App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\views\formpickereditor.html">
+      <PackagePath>App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\views\settings.html">
+      <PackagePath>App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Umbraco.Cms" Version="11.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms -->
+    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
+    <ProjectReference Include="..\Umbraco.Cms.Integrations.Crm.Hubspot\Umbraco.Cms.Integrations.Crm.Hubspot.csproj" />
+    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" Condition="$(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx')))" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Razor files are needed for the backoffice to work correctly -->
+    <CopyRazorGenerateFilesToPublishDirectory>true</CopyRazorGenerateFilesToPublishDirectory>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Remove RazorCompileOnBuild and RazorCompileOnPublish when not using ModelsMode InMemoryAuto -->
+    <RazorCompileOnBuild>false</RazorCompileOnBuild>
+    <RazorCompileOnPublish>false</RazorCompileOnPublish>
+  </PropertyGroup>
+  
+</Project>

--- a/src/Umbraco.Cms.Integrations.Testsite.V11/appsettings.Development.json
+++ b/src/Umbraco.Cms.Integrations.Testsite.V11/appsettings.Development.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "appsettings-schema.json",
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information"
+    },
+    "WriteTo": [
+      {
+        "Name": "Async",
+        "Args": {
+          "configure": [
+            {
+              "Name": "Console"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "Umbraco": {
+    "CMS": {
+      "Content": {
+        "MacroErrors": "Throw"
+      },
+      "Hosting": {
+        "Debug": true
+      },
+      "RuntimeMinification": {
+        "UseInMemoryCache": true,
+        "CacheBuster": "Timestamp"
+      }
+    }
+  }
+}

--- a/src/Umbraco.Cms.Integrations.Testsite.V11/appsettings.json
+++ b/src/Umbraco.Cms.Integrations.Testsite.V11/appsettings.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "appsettings-schema.json",
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "System": "Warning"
+      }
+    }
+  },
+  "Umbraco": {
+    "CMS": {
+      "Global": {
+        "Id": "8c8fb050-efbf-44ed-a170-6ad6e34069b5",
+        "SanitizeTinyMce": true
+      },
+      "Content": {
+        "AllowEditInvariantFromNonDefault": true,
+        "ContentVersionCleanupPolicy": {
+          "EnableCleanup": true
+        }
+      }
+    }
+  },
+  "ConnectionStrings": {
+    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
+  }
+}

--- a/src/Umbraco.Cms.Integrations.sln
+++ b/src/Umbraco.Cms.Integrations.sln
@@ -67,7 +67,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Search", "Search", "{F56605
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Algolia", "Algolia", "{F2CAA1F7-9BED-4EB6-8875-D176B92D393A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Umbraco.Cms.Integrations.Search.Algolia", "Umbraco.Cms.Integrations.Search.Algolia\Umbraco.Cms.Integrations.Search.Algolia.csproj", "{54A624E5-5321-4CC8-B74B-11ABF3605242}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Cms.Integrations.Search.Algolia", "Umbraco.Cms.Integrations.Search.Algolia\Umbraco.Cms.Integrations.Search.Algolia.csproj", "{54A624E5-5321-4CC8-B74B-11ABF3605242}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Umbraco.Cms.Integrations.Testsite.V11", "Umbraco.Cms.Integrations.Testsite.V11\Umbraco.Cms.Integrations.Testsite.V11.csproj", "{C3A51214-F058-4864-B0B2-4F788383A5EC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -131,6 +133,10 @@ Global
 		{54A624E5-5321-4CC8-B74B-11ABF3605242}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{54A624E5-5321-4CC8-B74B-11ABF3605242}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{54A624E5-5321-4CC8-B74B-11ABF3605242}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3A51214-F058-4864-B0B2-4F788383A5EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3A51214-F058-4864-B0B2-4F788383A5EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3A51214-F058-4864-B0B2-4F788383A5EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3A51214-F058-4864-B0B2-4F788383A5EC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Current PR fixes the Umbraco 11 compatibility issue reported [here](https://github.com/umbraco/Umbraco.Cms.Integrations/issues/63) caused by the removal of `IUserComposer`.
Fixed issue for HubSpot and updated package versioning based on targeting framework.