### PR TITLE
Http codes validations and refactoring

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/formpicker.controller.js
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/formpicker.controller.js
@@ -69,7 +69,7 @@
                         
                         if (response.isExpired === true || response.isValid === false) {
                             vm.loading = false;
-                            notificationsService.warning("HubSpot API", "Unable to connect to HubSpot. Please review the settings of the form picker property's data type.");
+                            notificationsService.warning("HubSpot API", response.error);
                             return;
                         }
 
@@ -78,7 +78,7 @@
                             vm.hubspotFormsList = data.forms;
 
                             if (data.isValid === false || data.isExpired === true) {
-                                notificationsService.error("HubSpot API", "Unable to retrieve the list of forms from HubSpot. Please review the settings of the form picker property's data type.");
+                                notificationsService.error("HubSpot API", response.error);
                             } else
                                 vm.isConnected = true;
                         });
@@ -91,7 +91,7 @@
                         vm.hubspotFormsList = data.forms;
 
                         if (data.isValid === false || data.isExpired === true) {
-                            notificationsService.error("HubSpot API", "Invalid API key");
+                            notificationsService.error("HubSpot API", data.error);
                         } else
                             vm.isConnected = true;
                     });

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/package.manifest
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/package.manifest
@@ -1,6 +1,6 @@
 ﻿{
   "name": "Umbraco.Cms.Integrations.Crm.Hubspot",
-  "version": "1.1.6",
+  "version": "2.0.0",
   "allowPackageTelemetry": true,
   "javascript": [
     "~/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/js/formpicker.controller.js",

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Constants.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Constants.cs
@@ -17,6 +17,21 @@
             public const string Settings = "Umbraco:Cms:Integrations:Crm:Hubspot:Settings";
         }
 
+        public static class ErrorMessages
+        {
+            public const string TokenPermissions = "Token does not have the required permissions.";
+
+            public const string InvalidApiKey = "Invalid API key.";
+
+            public const string ApiKeyMissing = "Cannot access Hubspot - API key is missing";
+
+            public const string AccessTokenMissing = "Cannot access Hubspot - Access Token is missing.";
+
+            public const string OAuthInvalidToken = "Unable to connect to HubSpot. Please review the settings of the form picker property's data type.";
+
+            public const string OAuthFetchFormsConfigurationFailed = "Unable to retrieve the list of forms from HubSpot. Please review the settings of the form picker property's data type.";
+        }
+
         internal static readonly JsonSerializerSettings SerializationSettings = new JsonSerializerSettings
         {
             MetadataPropertyHandling = MetadataPropertyHandling.Ignore,

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Models/Dtos/ResponseDto.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Models/Dtos/ResponseDto.cs
@@ -22,6 +22,9 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Models.Dtos
         [JsonProperty("isExpired")]
         public bool IsExpired { get; set; }
 
+        [JsonProperty("error")]
+        public string Error { get; set; }
+
         [JsonProperty("forms")]
         public List<HubspotFormDto> Forms { get; set; }
     }

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Resources/LoggingResources.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Resources/LoggingResources.cs
@@ -3,13 +3,9 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Resources
 {
     public static class LoggingResources
     {
-        public const string ApiKeyMissing = "Cannot access Hubspot - API key is missing";
-
         public const string ApiFetchFormsFailed =
             "Failed to fetch forms from Hubspot using API key: {0}";
 
         public const string OAuthFetchFormsFailed = "Failed to fetch forms from Hubspot using OAuth: {0}";
-
-        public const string AccessTokenMissing = "Cannot access Hubspot - Access Token is missing.";
     }
 }

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Crm.Hubspot</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.1.6</Version>
+		<Version>2.0.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/package.xml
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/package.xml
@@ -3,7 +3,7 @@
   <info>
     <package>
       <name>Umbraco.Cms.Integrations.Crm.Hubspot</name>
-      <version>1.1.5</version>
+      <version>2.0.0</version>
       <iconUrl></iconUrl>
       <licence url="https://opensource.org/licenses/MIT">MIT</licence>
       <url>https://github.com/umbraco/Umbraco.Cms.Integrations</url>


### PR DESCRIPTION
Current PR extends the updates made for issue #65 by handling HTTP requests in a `try-catch` block. 

With HubSpot's update to remove API key based access, HubSpot users who don't want to use OAuth need to create a private app with `forms` scope and then use the private access token in the package. If the private app is not configured properly, a `Forbidden` status code will be returned by the API. In this case a specific error message notifying that the token has the incorrect permissions will be returned to the user.

For consistency, I have also updated the OAuth specific action of the controller to align with the one used by the API key.

Error messages have been moved server-side and the controller has been refactored.