### PR TITLE
Split ActiveCampaign Core functionalities & support for Umbraco 11

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/ActiveCampaignComposer.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/ActiveCampaignComposer.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
+using System;
+
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Integrations.Crm.ActiveCampaign.Configuration;
+using Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Configuration;
 
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core
 {
     public class ActiveCampaignComposer : IComposer
     {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/ActiveCampaignFormPickerConfiguration.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/ActiveCampaignFormPickerConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿using Umbraco.Cms.Core.PropertyEditors;
 
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core
 {
     public class ActiveCampaignFormPickerConfiguration
     {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/ActiveCampaignFormPickerConfigurationEditor.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/ActiveCampaignFormPickerConfigurationEditor.cs
@@ -2,7 +2,7 @@
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
 
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core
 {
     public class ActiveCampaignFormPickerConfigurationEditor : ConfigurationEditor<ActiveCampaignFormPickerConfiguration>
     {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/ActiveCampaignFormPickerPropertyEditor.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/ActiveCampaignFormPickerPropertyEditor.cs
@@ -2,13 +2,13 @@
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
 
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core
 {
     [DataEditor(
         alias: Constants.PropertyEditorAlias,
         name: "ActiveCampaign Form Picker",
         view: "~/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/views/formpicker.html",
-        Group = Core.Constants.PropertyEditors.Groups.Pickers,
+        Group = Cms.Core.Constants.PropertyEditors.Groups.Pickers,
         Icon = "icon-activecampaign")]
     public class ActiveCampaignFormPickerPropertyEditor : DataEditor
     {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Configuration/ActiveCampaignSettings.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Configuration/ActiveCampaignSettings.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Configuration
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Configuration
 {
     public class ActiveCampaignSettings
     {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Constants.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Constants.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core
 {
     public class Constants
     {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Controllers/FormsController.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Controllers/FormsController.cs
@@ -1,15 +1,18 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
+using System;
+using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Threading.Tasks;
 
-using Umbraco.Cms.Integrations.Crm.ActiveCampaign.Configuration;
-using Umbraco.Cms.Integrations.Crm.ActiveCampaign.Models.Dtos;
+using Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Configuration;
+using Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Models.Dtos;
 using Umbraco.Cms.Web.BackOffice.Controllers;
 using Umbraco.Cms.Web.Common.Attributes;
 
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Controllers
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Controllers
 {
     [PluginController("UmbracoCmsIntegrationsCrmActiveCampaign")]
     public class FormsController : UmbracoAuthorizedApiController

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Editors/ActiveCampaignFormPickerValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Editors/ActiveCampaignFormPickerValueConverter.cs
@@ -1,12 +1,13 @@
 ﻿using Microsoft.Extensions.Options;
-using System.Text.Json.Nodes;
+
+using System;
 
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
-using Umbraco.Cms.Integrations.Crm.ActiveCampaign.Configuration;
-using Umbraco.Cms.Integrations.Crm.ActiveCampaign.Models.ViewModels;
+using Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Configuration;
+using Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Models.ViewModels;
 
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Editors
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Editors
 {
     public class ActiveCampaignFormPickerValueConverter : PropertyValueConverterBase
     {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Helpers/ActiveCampaignHtmlExtensions.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Helpers/ActiveCampaignHtmlExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
-using Umbraco.Cms.Integrations.Crm.ActiveCampaign.Models.ViewModels;
+using Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Models.ViewModels;
 
 namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Helpers
 {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/ApiAccessDto.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/ApiAccessDto.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Models.Dtos
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Models.Dtos
 {
     public class ApiAccessDto
     {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/BaseResponseDto.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/BaseResponseDto.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Models.Dtos
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Models.Dtos
 {
     public abstract class BaseResponseDto
     {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/FormCollectionResponseDto.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/FormCollectionResponseDto.cs
@@ -1,6 +1,7 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Models.Dtos
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Models.Dtos
 {
     public class FormCollectionResponseDto : BaseResponseDto
     {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/FormDto.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/FormDto.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Models.Dtos
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Models.Dtos
 {
     public class FormDto
     {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/FormResponseDto.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/FormResponseDto.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Models.Dtos
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Models.Dtos
 {
     public class FormResponseDto : BaseResponseDto
     {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/ViewModels/FormViewModel.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/ViewModels/FormViewModel.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Models.ViewModels
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Models.ViewModels
 {
     public class FormViewModel
     {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	
+	<PropertyGroup>
+		<TargetFrameworks>net60;net70</TargetFrameworks>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<WarningsAsErrors>Nullable</WarningsAsErrors>
+	</PropertyGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net60'">
+		<PackageReference Include="Umbraco.Cms.Web.Website" version="[10.0.0,11)" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[10.0.0,11)" />
+		<PackageReference Include="Umbraco.Cms.Web.Common" version="[10.0.0,11)" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net70'">
+		<PackageReference Include="Umbraco.Cms.Web.Website" version="[11.0.0,12)" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[11.0.0,12)" />
+		<PackageReference Include="Umbraco.Cms.Web.Common" version="[11.0.0,12)" />
+	</ItemGroup>
+
+</Project>

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.csproj
@@ -6,6 +6,18 @@
 		<WarningsAsErrors>Nullable</WarningsAsErrors>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<PackageId>Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core</PackageId>
+		<Title>Umbraco CMS Integrations: CRM - ActiveCampaign.Core</Title>
+		<Description>Core package for Umbraco CMS integration with ActiveCampaign.</Description>
+		<PackageIconUrl></PackageIconUrl>
+		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
+		<Version>2.0.0</Version>
+		<Authors>Umbraco HQ</Authors>
+		<Company>Umbraco</Company>
+	</PropertyGroup>
+
 	<ItemGroup Condition="'$(TargetFramework)' == 'net60'">
 		<PackageReference Include="Umbraco.Cms.Web.Website" version="[10.0.0,11)" />
 		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[10.0.0,11)" />

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/Umbraco.Cms.Integrations.Crm.ActiveCampaign.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/Umbraco.Cms.Integrations.Crm.ActiveCampaign.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>net60;net70</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<WarningsAsErrors>Nullable</WarningsAsErrors>
 	</PropertyGroup>
@@ -20,10 +20,16 @@
 		<PackageIcon>activecampaign.png</PackageIcon>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Umbraco.Cms.Web.Website" version="10.1.0" />
-		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="10.1.0" />
-		<PackageReference Include="Umbraco.Cms.Web.Common" version="10.1.0" />
+	<ItemGroup Condition="'$(TargetFramework)' == 'net60'">
+		<PackageReference Include="Umbraco.Cms.Web.Website" version="[10.0.0,11)" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[10.0.0,11)" />
+		<PackageReference Include="Umbraco.Cms.Web.Common" version="[10.0.0,11)" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net70'">
+		<PackageReference Include="Umbraco.Cms.Web.Website" version="[10.0.0,12)" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[11.0.0,12)" />
+		<PackageReference Include="Umbraco.Cms.Web.Common" version="[10.0.0,12)" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -56,6 +62,10 @@
 			<Pack>true</Pack>
 			<PackagePath>\</PackagePath>
 		</Content>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core\Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/Umbraco.Cms.Integrations.Crm.ActiveCampaign.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/Umbraco.Cms.Integrations.Crm.ActiveCampaign.csproj
@@ -13,24 +13,12 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.0.2</Version>
+		<Version>2.0.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
 		<PackageIcon>activecampaign.png</PackageIcon>
 	</PropertyGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net60'">
-		<PackageReference Include="Umbraco.Cms.Web.Website" version="[10.0.0,11)" />
-		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[10.0.0,11)" />
-		<PackageReference Include="Umbraco.Cms.Web.Common" version="[10.0.0,11)" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net70'">
-		<PackageReference Include="Umbraco.Cms.Web.Website" version="[10.0.0,12)" />
-		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[11.0.0,12)" />
-		<PackageReference Include="Umbraco.Cms.Web.Common" version="[10.0.0,12)" />
-	</ItemGroup>
 
 	<ItemGroup>
 		<Content Include="App_Plugins\UmbracoCms.Integrations\Crm\ActiveCampaign\**\*.*">

--- a/src/Umbraco.Cms.Integrations.sln
+++ b/src/Umbraco.Cms.Integrations.sln
@@ -69,7 +69,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Algolia", "Algolia", "{F2CA
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Cms.Integrations.Search.Algolia", "Umbraco.Cms.Integrations.Search.Algolia\Umbraco.Cms.Integrations.Search.Algolia.csproj", "{54A624E5-5321-4CC8-B74B-11ABF3605242}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Umbraco.Cms.Integrations.Testsite.V11", "Umbraco.Cms.Integrations.Testsite.V11\Umbraco.Cms.Integrations.Testsite.V11.csproj", "{C3A51214-F058-4864-B0B2-4F788383A5EC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Cms.Integrations.Testsite.V11", "Umbraco.Cms.Integrations.Testsite.V11\Umbraco.Cms.Integrations.Testsite.V11.csproj", "{C3A51214-F058-4864-B0B2-4F788383A5EC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core", "Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core\Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.csproj", "{14303AD9-B64B-4DE1-AB4E-B0979277EAC2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -137,6 +139,10 @@ Global
 		{C3A51214-F058-4864-B0B2-4F788383A5EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C3A51214-F058-4864-B0B2-4F788383A5EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C3A51214-F058-4864-B0B2-4F788383A5EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14303AD9-B64B-4DE1-AB4E-B0979277EAC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14303AD9-B64B-4DE1-AB4E-B0979277EAC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14303AD9-B64B-4DE1-AB4E-B0979277EAC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14303AD9-B64B-4DE1-AB4E-B0979277EAC2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -162,6 +168,7 @@ Global
 		{8FC3A87F-C10E-4605-9D24-BFF46D472170} = {1A4D3D38-F5B2-4528-92A1-318A7D09949D}
 		{F2CAA1F7-9BED-4EB6-8875-D176B92D393A} = {F56605AE-2258-4F61-B454-4247334DFC26}
 		{54A624E5-5321-4CC8-B74B-11ABF3605242} = {F2CAA1F7-9BED-4EB6-8875-D176B92D393A}
+		{14303AD9-B64B-4DE1-AB4E-B0979277EAC2} = {1A4D3D38-F5B2-4528-92A1-318A7D09949D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FB51E08-A3C8-4DFF-B3CB-E99C2ED021D5}


### PR DESCRIPTION
Separate ActiveCampaign Core implementations per request in issue #69 and support for Umbraco 11.