### PR TITLE
Folder structured content types bug and version bump.

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/js/algolia.service.js
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/js/algolia.service.js
@@ -1,17 +1,32 @@
 ﻿function algoliaService(contentTypeResource) {
     return {
         getContentTypes: function (callback) {
+
             contentTypeResource.getAll().then(function (data) {
-                callback(data.filter(item => item.parentId == -1 && !item.isElement).map((item) => {
-                    return {
-                        id: item.id,
-                        icon: item.icon,
-                        alias: item.alias,
-                        name: item.name,
-                        selected: false,
-                        allowRemove: false
+
+                var contentTypesArr = [];
+
+                for (let i = 0; i < data.length; i++) {
+                    
+                    if (data[i].isElement) continue;
+
+                    contentTypeResource.getWhereCompositionIsUsedInContentTypes(data[i].id).then(function (response) {
+                        if (response.length === 0) {
+                            contentTypesArr.push({
+                                id: data[i].id,
+                                icon: data[i].icon,
+                                alias: data[i].alias,
+                                name: data[i].name,
+                                selected: false,
+                                allowRemove: false
+                            });
+                        }
+                    });
+
+                    if (data.length - 1 === i) {
+                        callback(contentTypesArr);
                     }
-                }));
+                }
             });
         },
         getPropertiesByContentTypeId: function (contentTypeId, callback) {

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/js/algolia.service.js
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/js/algolia.service.js
@@ -10,23 +10,17 @@
                     
                     if (data[i].isElement) continue;
 
-                    contentTypeResource.getWhereCompositionIsUsedInContentTypes(data[i].id).then(function (response) {
-                        if (response.length === 0) {
-                            contentTypesArr.push({
-                                id: data[i].id,
-                                icon: data[i].icon,
-                                alias: data[i].alias,
-                                name: data[i].name,
-                                selected: false,
-                                allowRemove: false
-                            });
-                        }
+                    contentTypesArr.push({
+                        id: data[i].id,
+                        icon: data[i].icon,
+                        alias: data[i].alias,
+                        name: data[i].name,
+                        selected: false,
+                        allowRemove: false
                     });
-
-                    if (data.length - 1 === i) {
-                        callback(contentTypesArr);
-                    }
                 }
+
+                callback(contentTypesArr);
             });
         },
         getPropertiesByContentTypeId: function (contentTypeId, callback) {

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/package.manifest
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/package.manifest
@@ -1,6 +1,6 @@
 ﻿{
 	"name": "Umbraco.Cms.Integrations.Search.Algolia",
-	"version": "1.0.0",
+	"version": "1.1.1",
 	"allowPackageTelemetry": true,
 	"javascript": [
 		"~/App_Plugins/UmbracoCms.Integrations/Search/Algolia/js/algolia.service.js",

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Search.Algolia</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.1.0</Version>
+		<Version>1.1.1</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
This PR fixes the issue reported [here](https://github.com/umbraco/Umbraco.Cms.Integrations/issues/70#issuecomment-1378950038), where content types structured in directories did not get retrieved when creating an index.

This was a consequence of the `contentTypeItem.parentId == -1` clause which was intended to skip composition elements.

The fix retrieves the entire list of content types, skips those that have the `isElement` flag `true`, and I use the `getWhereCompositionIsUsedInContentTypes` function of the API to check is the object is used as a composition.