### PR TITLE
Handling HTTP exceptions

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Controllers/FormsController.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Controllers/FormsController.cs
@@ -120,13 +120,10 @@ namespace Umbraco.Cms.Integrations.Crm.Dynamics.Controllers
 
                 return result;
 
-            } else
-            {
-                var errorResult = await response.Content.ReadAsStringAsync();
-                var errorDto = JsonConvert.DeserializeObject<ErrorDto>(errorResult);
+            var errorResult = await response.Content.ReadAsStringAsync();
+            var errorDto = JsonConvert.DeserializeObject<ErrorDto>(errorResult);
 
-                return "Error: " + errorDto.ErrorDescription;
-            }
+            return "Error: " + errorDto.ErrorDescription;
         }
 
         [HttpGet]

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Controllers/FormsController.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Controllers/FormsController.cs
@@ -105,7 +105,7 @@ namespace Umbraco.Cms.Integrations.Crm.Dynamics.Controllers
             requestMessage.Headers.Add("service_name", AuthorizationService.Service);
 
             var response = await ClientFactory().SendAsync(requestMessage);
-            if(response.IsSuccessStatusCode)
+            if (response.IsSuccessStatusCode)
             {
                 var result = await response.Content.ReadAsStringAsync();
 


### PR DESCRIPTION
This PR is a follow up of issue #77 , where the secret key of the Azure App handling authentication expired, causing `401 Unauthorized` responses. The message displayed to the user was `Error: An unexpected error occurred.` without relevant information towards the error.

With this update, this scenario will be managed better in the future.