### PR TITLE
Fix variant issue

### DIFF
--- a/src/Umbraco.Cms.Integrations.PIM.Inriver/App_Plugins/UmbracoCms.Integrations/PIM/Inriver/js/entitypickereditor.controller.js
+++ b/src/Umbraco.Cms.Integrations.PIM.Inriver/App_Plugins/UmbracoCms.Integrations/PIM/Inriver/js/entitypickereditor.controller.js
@@ -54,7 +54,9 @@
         var fieldTypes = $scope.model.configuration.fieldTypes;
 
         vm.loading = true;
-        umbracoCmsIntegrationsPimInriverResource.query($scope.model.configuration, currentVariant.language.culture).then(function (response) {
+        umbracoCmsIntegrationsPimInriverResource.query(
+            $scope.model.configuration,
+            currentVariant.language != null ? currentVariant.language.culture : "").then(function (response) {
             if (response.success) {
                 vm.entities = response.data.map(obj => {
                     return {

--- a/src/Umbraco.Cms.Integrations.PIM.Inriver/Controllers/EntityController.cs
+++ b/src/Umbraco.Cms.Integrations.PIM.Inriver/Controllers/EntityController.cs
@@ -46,7 +46,10 @@ namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Controllers
         [HttpPost]
         public async Task<IActionResult> Query([FromBody] QueryRequest request)
         {
-            var language = _localizationService.GetLanguageByIsoCode(request.Culture);
+            var language = _localizationService.GetLanguageByIsoCode(
+                string.IsNullOrEmpty(request.Culture) 
+                    ? _localizationService.GetDefaultLanguageIsoCode()
+                    : request.Culture);
 
             var result = await _inriverService.Query(new QueryRequest
             {


### PR DESCRIPTION
Current PR fixes a bug regarding content node variants. If a content node does not have variants, a `NULL` exception was thrown on the client when trying to retrieve the culture using `currentVariant.language.culture`.

To fix this, I am sending an empty string with the request, and pick the default language on the server.