### PR TITLE
OAuth handling

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/App_Plugins/UmbracoCms.Integrations/Crm/Dynamics/js/configuration.controller.js
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/App_Plugins/UmbracoCms.Integrations/Crm/Dynamics/js/configuration.controller.js
@@ -19,6 +19,7 @@
 
     vm.onConnectClick = function () {
 
+        window.addEventListener("message", getAccessToken, false);
         umbracoCmsIntegrationsCrmDynamicsResource.getAuthorizationUrl().then(function (response) {
             vm.authWindow = window.open(response,
                 "Authorize", "width=900,height=700,modal=yes,alwaysRaised=yes");
@@ -37,17 +38,18 @@
 
             if (typeof $scope.revoked === "function")
                 $scope.revoked();
+
+            vm.oauthSuccessEventCount = 0;
+            window.removeEventListener("message", getAccessToken);
         });
     }
 
-    // authorization listener
-    window.addEventListener("message", function (event) {
+    function getAccessToken(event) {
         if (event.data.type === "hubspot:oauth:success") {
             vm.oauthSuccessEventCount += 1;
 
             if (vm.oauthSuccessEventCount == 1) {
                 umbracoCmsIntegrationsCrmDynamicsResource.getAccessToken(event.data.code).then(function (response) {
-
                     if (response.startsWith("Error:")) {
 
                         // if directive runs from property editor, the notifications should be hidden, because they will not be displayed properly behind the overlay window.
@@ -72,7 +74,7 @@
                 });
             }
         }
-    }, false);
+    }
 }
 
 angular.module("umbraco")

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Services/DynamicsService.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Services/DynamicsService.cs
@@ -110,7 +110,9 @@ namespace Umbraco.Cms.Integrations.Crm.Dynamics.Services
 
             if (!response.IsSuccessStatusCode)
             {
-                return JsonConvert.DeserializeObject<IdentityDto>(result);
+                return !string.IsNullOrEmpty(result) 
+                    ? JsonConvert.DeserializeObject<IdentityDto>(result)
+                    : new IdentityDto { IsAuthorized = false };
             }
 
             return new IdentityDto

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Umbraco.Cms.Integrations.Crm.Dynamics.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Umbraco.Cms.Integrations.Crm.Dynamics.csproj
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Crm.Dynamics</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.1.2</Version>
+		<Version>1.1.3</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Crm.Hubspot</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>2.0.0</Version>
+		<Version>2.0.1</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>

--- a/src/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.UrlInspectionTool/App_Plugins/UmbracoCms.Integrations/SEO/GoogleSearchConsole/URLInspectionTool/js/url-inspection-tool.controller.js
+++ b/src/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.UrlInspectionTool/App_Plugins/UmbracoCms.Integrations/SEO/GoogleSearchConsole/URLInspectionTool/js/url-inspection-tool.controller.js
@@ -5,7 +5,6 @@
     vm.showResults = false;
     vm.oauthConfiguration = {};
     vm.inspectionResult = {};
-    vm.oauthSuccessEventCount = 0;
 
     // build default url inspection object
     var nodeUrls = getUrls();
@@ -33,7 +32,6 @@
     vm.onRevokeToken = function () {
         revokeToken();
 
-        vm.oauthSuccessEventCount = 0;
         window.removeEventListener("message", getAccessToken);
     }
 
@@ -80,8 +78,6 @@
 
     function getAccessToken(event) {
         if (event.data.type === "google:oauth:success") {
-            vm.oauthSuccessEventCount += 1;
-
             var codeParam = "?code=";
             var scopeParam = "&scope=";
 
@@ -89,16 +85,15 @@
 
             var code = event.data.url.slice(event.data.url.indexOf(codeParam) + codeParam.length, event.data.url.indexOf(scopeParam));
 
-            if (vm.oauthSuccessEventCount == 1) {
-                umbracoCmsIntegrationsGoogleSearchConsoleUrlInspectionToolResource.getAccessToken(code).then(function (response) {
-                    if (response !== "error") {
-                        vm.oauthConfiguration.isConnected = true;
-                        notificationsService.success("Google Search Console Authorization", "Access Approved");
-                    } else {
-                        notificationsService.error("Google Search Console Authorization", "Access Denied");
-                    }
-                });
-            }
+            umbracoCmsIntegrationsGoogleSearchConsoleUrlInspectionToolResource.getAccessToken(code).then(function (response) {
+                if (response !== "error") {
+                    vm.oauthConfiguration.isConnected = true;
+                    notificationsService.success("Google Search Console Authorization", "Access Approved");
+                } else {
+                    notificationsService.error("Google Search Console Authorization", "Access Denied");
+                }
+            });
+
         } else if (event.data.type === "google:oauth:denied") {
             notificationsService.error("Google Search Console Authorization", "Access Denied");
             vm.oauthConfiguration.isConnected = false;

--- a/src/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.UrlInspectionTool/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.URLInspectionTool.csproj
+++ b/src/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.UrlInspectionTool/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.URLInspectionTool.csproj
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.UrlInspectionTool</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>0.1.3</Version>
+		<Version>1.0.3</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>

--- a/src/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.UrlInspectionTool/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.URLInspectionTool.csproj
+++ b/src/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.UrlInspectionTool/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.URLInspectionTool.csproj
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.UrlInspectionTool</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>0.1.2</Version>
+		<Version>0.1.3</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
@@ -56,5 +56,4 @@
 			<Analyzer Remove="@(Analyzer)" Condition="%(FileName) == 'Lucene.Net.CodeAnalysis.CSharp'" />
 		</ItemGroup>
 	</Target>
-
 </Project>

--- a/src/Umbraco.Cms.Integrations.SEO.Semrush/App_Plugins/UmbracoCms.Integrations/SEO/Semrush/semrush.controller.js
+++ b/src/Umbraco.Cms.Integrations.SEO.Semrush/App_Plugins/UmbracoCms.Integrations/SEO/Semrush/semrush.controller.js
@@ -20,11 +20,9 @@
 
         var vm = this;
 
-        vm.oauthSuccessEventCount = 0;
-
         userService.getCurrentUser().then(function (user) {
             var isPartOfAdminUserGroup = user.userGroups.find(x => x === "admin");
-            
+
             vm.isAdmin = isPartOfAdminUserGroup !== undefined;
         });
 
@@ -173,7 +171,6 @@
 
         function getAccessToken(event) {
             if (event.data.type === "semrush:oauth:success") {
-                vm.oauthSuccessEventCount += 1;
 
                 var codeParam = "?code=";
 
@@ -181,17 +178,16 @@
 
                 var code = event.data.url.slice(event.data.url.indexOf(codeParam) + codeParam.length);
 
-                if (vm.oauthSuccessEventCount == 1) {
-                    umbracoCmsIntegrationsSemrushResource.getAccessToken(code).then(function (response) {
-                        if (response !== "error") {
-                            vm.isConnected = true;
-                            vm.showSuccess("Semrush authentication", "Access Approved");
-                            validateToken();
-                        } else {
-                            vm.showError("Semrush authentication", "Access Denied");
-                        }
-                    });
-                }
+                umbracoCmsIntegrationsSemrushResource.getAccessToken(code).then(function (response) {
+                    if (response !== "error") {
+                        vm.isConnected = true;
+                        vm.showSuccess("Semrush authentication", "Access Approved");
+                        validateToken();
+                    } else {
+                        vm.showError("Semrush authentication", "Access Denied");
+                    }
+                });
+
             } else if (event.data.type === "semrush:oauth:denied") {
                 vm.showError("Semrush authentication", "Access Denied");
 
@@ -220,7 +216,6 @@
                 vm.isFreeAccount = null;
                 vm.searchKeywordsList = {};
 
-                vm.oauthSuccessEventCount = 0;
                 window.removeEventListener("message", getAccessToken);
             });
         }

--- a/src/Umbraco.Cms.Integrations.SEO.Semrush/Controllers/SemrushController.cs
+++ b/src/Umbraco.Cms.Integrations.SEO.Semrush/Controllers/SemrushController.cs
@@ -99,16 +99,17 @@ namespace Umbraco.Cms.Integrations.SEO.Semrush.Controllers
             requestMessage.Headers.Add(SemrushSettings.SemrushServiceHeaderKey.Key, SemrushSettings.SemrushServiceHeaderKey.Value);
 
             var response = await ClientFactory().SendAsync(requestMessage);
+
+            var result = await response.Content.ReadAsStringAsync();
+
             if (response.IsSuccessStatusCode)
             {
-                var result = await response.Content.ReadAsStringAsync();
-
                 _semrushTokenService.SaveParameters(SemrushSettings.TokenDbKey, result);
 
                 return result;
             }
 
-            return "error";
+            return "Error: " + result;
         }
 
         [HttpPost]

--- a/src/Umbraco.Cms.Integrations.SEO.Semrush/Umbraco.Cms.Integrations.SEO.Semrush.csproj
+++ b/src/Umbraco.Cms.Integrations.SEO.Semrush/Umbraco.Cms.Integrations.SEO.Semrush.csproj
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.SEO.Semrush</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.1.2</Version>
+		<Version>1.1.3</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
@@ -61,5 +61,4 @@
 			<Analyzer Remove="@(Analyzer)" Condition="%(FileName) == 'Lucene.Net.CodeAnalysis.CSharp'" />
 		</ItemGroup>
 	</Target>
-
 </Project>


### PR DESCRIPTION
Current PR handles an old issue regarding authorization using the OAuth protocol, where in some scenarios, due to multiple event listeners registered in the `window` object for the `message` event, when the authorization code was received, multiple requests to retrieve an access token were issued, resulting in a strange UI behavior and error notifications.

The solution to this was to add and remove listeners on _Connect_ or _Revoke_, assuring this way that a single event was "listened" to. As a backup, I keep track of the number of requests sent, ensuring that only one is sent.