### PR TITLE
Cookiebot integration draft

### DIFF
--- a/src/Umbraco.Cms.Integrations.Script.Cookiebot/Constants.cs
+++ b/src/Umbraco.Cms.Integrations.Script.Cookiebot/Constants.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Umbraco.Cms.Integrations.Script.Cookiebot
+{
+    public class Constants
+    {
+        public const string SettingsPath = "Umbraco:Cms:Integrations:Script:Cookiebot:Settings";
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Script.Cookiebot/Umbraco.Cms.Integrations.Script.Cookiebot.csproj
+++ b/src/Umbraco.Cms.Integrations.Script.Cookiebot/Umbraco.Cms.Integrations.Script.Cookiebot.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Umbraco.Cms.Web.Website" version="[10.3.0,12)" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[10.3.0,12)" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Content Include="Views\Partials\UmbracoCms.Integrations\Scripts\Cookiebot\**\*.*">
+			<Pack>true</Pack>
+			<PackagePath>Views\Partials\UmbracoCms.Integrations\Scripts\Cookiebot\</PackagePath>
+		</Content>
+		<None Include="build\**\*.*">
+			<Pack>True</Pack>
+			<PackagePath>buildTransitive</PackagePath>
+		</None>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <Content Remove="Views\Partials\UmbracoCms.Integrations\Scripts\Cookiebot\Cookiebot.cshtml~RF11f2acff.TMP" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <None Remove="Views\Partials\UmbracoCms.Integrations\Scripts\Cookiebot\Cookiebot.cshtml~RF11f2acff.TMP" />
+	</ItemGroup>
+
+</Project>

--- a/src/Umbraco.Cms.Integrations.Script.Cookiebot/Views/Partials/UmbracoCms.Integrations/Scripts/Cookiebot/Cookiebot.cshtml
+++ b/src/Umbraco.Cms.Integrations.Script.Cookiebot/Views/Partials/UmbracoCms.Integrations/Scripts/Cookiebot/Cookiebot.cshtml
@@ -1,0 +1,14 @@
+﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
+
+@inject Microsoft.Extensions.Configuration.IConfiguration Configuration
+
+@using Umbraco.Cms.Integrations.Script.Cookiebot
+
+@{
+    var scriptSrc = "https://consent.cookiebot.com/" + Configuration[$"{Constants.SettingsPath}:Id"] + "/cd.js";
+}
+
+<script id="CookieDeclaration" 
+    src="@scriptSrc" 
+    type="text/javascript" async></script>
+

--- a/src/Umbraco.Cms.Integrations.Script.Cookiebot/build/Umbraco.Cms.Integrations.Script.Cookiebot.targets
+++ b/src/Umbraco.Cms.Integrations.Script.Cookiebot/build/Umbraco.Cms.Integrations.Script.Cookiebot.targets
@@ -1,0 +1,29 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<CookiebotPropertyEditorFilesPath>
+			$(MSBuildThisFileDirectory)..\Views\Partials\UmbracoCms.Integrations\Scripts\Cookiebot\**\*.*
+		</CookiebotPropertyEditorFilesPath>
+	</PropertyGroup>
+	<Target Name="CopyCookiebotPropertyEditorAssets" BeforeTargets="Build">
+		<ItemGroup>
+			<CookiebotPropertyEditorFiles Include="$(CookiebotPropertyEditorFilesPath)" />
+		</ItemGroup>
+		<Message
+			Text="Copying Cookiebot Property Editor files: $(CookiebotPropertyEditorFilesPath) - #@(CookiebotPropertyEditorFiles->Count()) files"
+			Importance="high" />
+		<Copy SourceFiles="@(CookiebotPropertyEditorFiles)"
+		      DestinationFiles="@(CookiebotPropertyEditorFiles->'$(MSBuildProjectDirectory)\Views\Partials\UmbracoCms.Integrations\Scripts\Cookiebot\%(RecursiveDir)%(Filename)%(Extension)')"
+		      SkipUnchangedFiles="true" />
+
+	</Target>
+
+	<Target Name="ClearCookiebotPropertyEditorAssets" BeforeTargets="Clean">
+		<ItemGroup>
+			<CookiebotPropertyEditorDir
+				Include="$(MSBuildProjectDirectory)\Views\Partials\UmbracoCms.Integrations\Scripts\Cookiebot\" />
+		</ItemGroup>
+		<Message Text="Clear old Cookiebot Property Editor data"  Importance="high" />
+		<RemoveDir Directories="@(CookiebotPropertyEditorDir)"  />
+	</Target>
+
+</Project>

--- a/src/Umbraco.Cms.Integrations.sln
+++ b/src/Umbraco.Cms.Integrations.sln
@@ -77,6 +77,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Cms.Integrations.PI
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core", "Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core\Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.csproj", "{14303AD9-B64B-4DE1-AB4E-B0979277EAC2}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "General", "General", "{54684516-D990-41C7-885E-96A064A55BB1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Umbraco.Cms.Integrations.Script.Cookiebot", "Umbraco.Cms.Integrations.Script.Cookiebot\Umbraco.Cms.Integrations.Script.Cookiebot.csproj", "{B6830012-7233-41D5-8CD5-E67635388806}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -151,6 +155,10 @@ Global
 		{14303AD9-B64B-4DE1-AB4E-B0979277EAC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{14303AD9-B64B-4DE1-AB4E-B0979277EAC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{14303AD9-B64B-4DE1-AB4E-B0979277EAC2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6830012-7233-41D5-8CD5-E67635388806}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6830012-7233-41D5-8CD5-E67635388806}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6830012-7233-41D5-8CD5-E67635388806}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6830012-7233-41D5-8CD5-E67635388806}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -178,6 +186,7 @@ Global
 		{54A624E5-5321-4CC8-B74B-11ABF3605242} = {F2CAA1F7-9BED-4EB6-8875-D176B92D393A}
 		{904B3CF6-1015-465E-8244-70FC90466F22} = {B5D14B4B-0E39-4C01-9021-D9A75F358DE1}
 		{14303AD9-B64B-4DE1-AB4E-B0979277EAC2} = {1A4D3D38-F5B2-4528-92A1-318A7D09949D}
+		{B6830012-7233-41D5-8CD5-E67635388806} = {54684516-D990-41C7-885E-96A064A55BB1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FB51E08-A3C8-4DFF-B3CB-E99C2ED021D5}


### PR DESCRIPTION
This PR contains a PoC of an integration with [Cookiebot](https://www.cookiebot.com/en/help/) in support of the initiative to allow different partners with script based products to integrate easily with Umbraco.

The integration provides a partial view where custom JavaScript can be inserted and the client specific property values are going to be pulled from the website's settings file.

The partial view will then be loaded anywhere using this syntax `@await Html.PartialAsync("~/Views/Partials/UmbracoCms.Integrations/Scripts/Cookiebot/Cookiebot.cshtml")`.

As this is just a proof of concept, the naming could be improved.