### PR TITLE
Include Search API key

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Configuration/AlgoliaSettings.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Configuration/AlgoliaSettings.cs
@@ -7,6 +7,6 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Configuration
 
         public string AdminApiKey { get; set; }
 
-        public string ApiKey { get; set; }
+        public string SearchApiKey { get; set; }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchService.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchService.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 
         public SearchResponse<Record> Search(string indexName, string query)
         {
-            var client = new SearchClient(_settings.ApplicationId, _settings.AdminApiKey);
+            var client = new SearchClient(_settings.ApplicationId, _settings.SearchApiKey);
             
             var index = client.InitIndex(indexName);
             


### PR DESCRIPTION
Current PR introduces the additional Search API key as part of the Algolia settings, for a safe use to perform searches on the frontend.

With this update, I am addressing issue #97 and the input provided there.