### PR TITLE
Fix indexing for empty RTEs

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 
             var indexValues = dataType.Editor.PropertyIndexValueFactory.GetIndexValues(property, culture, string.Empty, true);
 
-            if(indexValues == null) return default;
+            if (indexValues == null || !indexValues.Any()) return new KeyValuePair<string, string>(property.Alias, string.Empty);
 
             var indexValue = indexValues.FirstOrDefault();
 
@@ -67,7 +67,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 
             var parsedIndexValue = ParseIndexValue(indexValue.Value);
 
-            if(string.IsNullOrEmpty(parsedIndexValue)) return string.Empty;
+            if (string.IsNullOrEmpty(parsedIndexValue)) return string.Empty;
 
             var inputMedia = JsonSerializer.Deserialize<IEnumerable<MediaItem>>(parsedIndexValue);
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Search.Algolia</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.3.1</Version>
+		<Version>1.3.2</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR fixes issue #105 , when indexing an empty RTE throws an exception. Also, instead of returning the default value of the `KeyValuePair` type, I still add the selected indexed property to the record payload, but with an empty value.