### PR TITLE
Allow properties to be in the varyByCulture state and without if the …

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
@@ -4,6 +4,7 @@ using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Integrations.Search.Algolia.Models;
 using Umbraco.Cms.Integrations.Search.Algolia.Services;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
 {
@@ -60,7 +61,8 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
             {
                 if (!_record.Data.ContainsKey(property.Alias))
                 {
-                    if (content.PublishedCultures.Count() > 0)
+                   
+                    if (property.PropertyType.VariesByCulture())
                     {
                         foreach (var culture in content.PublishedCultures)
                         {


### PR DESCRIPTION
If node was set to VaryByCulture the builder will look at the properties to all be VaryByCulture.

But we could have some properties with out the VaryByCulture settings.

We now look for VaryByCulture on each property instead of only checking if the node is VaryByCulture.