### PR TITLE
Update package.manifest in ActiveCampaign integration

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/package.manifest
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/package.manifest
@@ -1,14 +1,14 @@
-﻿{
+{
 	"name": "Umbraco.Cms.Integrations.Crm.ActiveCampaign",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"allowPackageTelemetry": true,
 	"javascript": [
 		"~/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/js/configuration.controller.js",
 		"~/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/js/formpicker.controller.js",
-		"~/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/js/activecampaign.resource.js",
-		"~/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/js/configuration.directive.js"
+		"~/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/js/activecampaign.resource.js"
 	],
 	"css": [
 		"~/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/css/styles.css"
-	]
+	],
+	"bundleOptions": "None"
 }


### PR DESCRIPTION
We kept having issues when Umbraco was running in production mode, and after a while we figured out we need to have the following line inside package.manifest

"bundleOptions": "None" 

And then i removed one line which was not included