### PR TITLE
Toggle API key validation between CMS and Forms package settings

### DIFF
--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Configuration/AppSettings.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Configuration/AppSettings.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Umbraco.Cms.Integrations.Automation.Zapier.Configuration
+{
+    public abstract class AppSettings
+    {
+        public string UserGroupAlias { get; set; }
+
+        public string ApiKey { get; set; }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Configuration/ZapierFormsSettings.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Configuration/ZapierFormsSettings.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Specialized;
+
+namespace Umbraco.Cms.Integrations.Automation.Zapier.Configuration
+{
+    public class ZapierFormsSettings : ZapierSettings
+    {
+        public ZapierFormsSettings()
+        {
+
+        }
+
+        public ZapierFormsSettings(NameValueCollection appSettings)
+        {
+            UserGroupAlias = appSettings[Constants.UmbracoFormsIntegrationsAutomationZapierUserGroupAlias];
+
+            ApiKey = appSettings[Constants.UmbracoFormsIntegrationsAutomationZapierApiKey];
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Configuration/ZapierSettings.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Configuration/ZapierSettings.cs
@@ -2,7 +2,7 @@
 
 namespace Umbraco.Cms.Integrations.Automation.Zapier.Configuration
 {
-    public class ZapierSettings
+    public class ZapierSettings : AppSettings
     {
         public ZapierSettings()
         {
@@ -15,9 +15,5 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Configuration
 
             ApiKey = appSettings[Constants.UmbracoCmsIntegrationsAutomationZapierApiKey];
         }
-
-        public string UserGroupAlias { get; set; }
-
-        public string ApiKey { get; set; }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Constants.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Constants.cs
@@ -13,6 +13,10 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier
 
         public const string UmbracoCmsIntegrationsAutomationZapierApiKey = "Umbraco.Cms.Integrations.Automation.Zapier.ApiKey";
 
+        public const string UmbracoFormsIntegrationsAutomationZapierUserGroupAlias = "Umbraco.Forms.Integrations.Automation.Zapier.UserGroupAlias";
+
+        public const string UmbracoFormsIntegrationsAutomationZapierApiKey = "Umbraco.Forms.Integrations.Automation.Zapier.ApiKey";
+
         public static class ZapierAppConfiguration
         {
             public const string UsernameHeaderKey = "X-USERNAME";
@@ -25,6 +29,8 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier
         public static class Configuration
         {
             public const string Settings = "Umbraco:Cms:Integrations:Automation:Zapier:Settings";
+
+            public const string FormsSettings = "Umbraco:Forms:Integrations:Automation:Zapier:Settings";
         }
 
         public static class ContentProperties

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/AuthController.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/AuthController.cs
@@ -28,6 +28,7 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Controllers
         }
 
         [HttpPost]
-        public async Task<bool> ValidateUser([FromBody] UserModel userModel) => await _userValidationService.Validate(userModel.Username, userModel.Password, userModel.ApiKey);
+        public async Task<bool> ValidateUser([FromBody] UserModel userModel) => 
+            await _userValidationService.Validate(userModel.Username, userModel.Password, userModel.ApiKey);
     }
 }

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/ZapierComposer.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/ZapierComposer.cs
@@ -21,9 +21,12 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier
 #if NETCOREAPP
         public void Compose(IUmbracoBuilder builder)
         {
-            var options = builder.Services
+            builder.Services
                 .AddOptions<ZapierSettings>()
                 .Bind(builder.Config.GetSection(Constants.Configuration.Settings));
+            builder.Services
+                .AddOptions<ZapierFormsSettings>()
+                .Bind(builder.Config.GetSection(Constants.Configuration.FormsSettings));
 
             builder
                 .AddNotificationHandler<UmbracoApplicationStartingNotification, UmbracoAppStartingHandler>();


### PR DESCRIPTION
Current PR is a result of the tests made for [this](https://github.com/umbraco/Umbraco.Forms.Integrations/issues/86) Zapier Forms issue, where an exception is shown when trying to retrieve the list of forms.

Trying to replicate the use case, I have identified an issue when trying to authenticate an user, regarding the base URL, which could be saved with a trailing slash `/`, causing the next API requests to fail.

When a user sets up a new Zap and configures the trigger, he needs to
- pick an app and select an event:
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/95346674/898e2311-6368-497c-ac24-c40f2cffc3f4)

- set up an account and authenticate it against the Umbraco website through an API key, or credentials:
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/95346674/c313d0ce-a3ab-4fb1-b7c8-28aacfb7321e)

In the account configuration window, if the base URL was not inputted properly, any `404` responses would have been handled incorrectly because the Zapier App response handling code looks only for a `false` content: 
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/95346674/9a7ff6f3-3dc8-4e57-911f-b34bcde1628b)
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/95346674/311196a2-c66b-40a7-801b-c95237efc63f)

Additionally, the authorization service from the CMS package would lookup the API key in the CMS settings, instead of picking them from Forms settings.

Applied fixes:
- Handle the response based on the HTTP status code and then check the content of the response: 
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/95346674/7278a4de-fb9a-4096-b126-4f504b3017c7)
- When validating user access, if CMS settings are missing, move and check the settings for Forms.

Currently the Zapier App changes under version 2.1.0 are in private mode, once the package update will be ready, I will make them public.
