### PR TITLE
Fix deprecated method invocation

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
@@ -61,7 +61,6 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
             {
                 if (!_record.Data.ContainsKey(property.Alias))
                 {
-                   
                     if (property.PropertyType.VariesByCulture())
                     {
                         foreach (var culture in content.PublishedCultures)

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Integrations.Search.Algolia.Models;
@@ -65,13 +64,13 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
                     {
                         foreach (var culture in content.PublishedCultures)
                         {
-                            var indexValue = _algoliaSearchPropertyIndexValueFactory.GetValue(property, culture);
+                            var indexValue = _algoliaSearchPropertyIndexValueFactory.GetValue(property, culture, content.AvailableCultures);
                             _record.Data.Add($"{indexValue.Key}-{culture}", indexValue.Value);
                         }
                     }
                     else
                     {
-                        var indexValue = _algoliaSearchPropertyIndexValueFactory.GetValue(property, string.Empty);
+                        var indexValue = _algoliaSearchPropertyIndexValueFactory.GetValue(property, string.Empty, Enumerable.Empty<string>());
                         _record.Data.Add(indexValue.Key, indexValue.Value);
                     }
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
@@ -2,6 +2,7 @@
 
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 {
@@ -11,11 +12,15 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 
         private readonly IMediaService _mediaService;
 
-        public AlgoliaSearchPropertyIndexValueFactory(IDataTypeService dataTypeService, IMediaService mediaService)
+        private readonly IEnumerable<string> _availableLanguages;
+
+        public AlgoliaSearchPropertyIndexValueFactory(IDataTypeService dataTypeService, IMediaService mediaService, ILocalizationService localizationService)
         {
             _dataTypeService = dataTypeService;
 
             _mediaService = mediaService;
+
+            _availableLanguages = localizationService.GetAllLanguages().Select(p => p.IsoCode);
 
             Converters = new Dictionary<string, Func<KeyValuePair<string, IEnumerable<object>>, string>>
             {
@@ -29,11 +34,11 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
         {
             var dataType = _dataTypeService.GetByEditorAlias(property.PropertyType.PropertyEditorAlias)
                 .FirstOrDefault(p => p.Id == property.PropertyType.DataTypeId);
-
+         
             if (dataType == null) return default;
 
-            var indexValues = dataType.Editor.PropertyIndexValueFactory.GetIndexValues(property, culture, string.Empty, true);
-
+            var indexValues = dataType.Editor.PropertyIndexValueFactory.GetIndexValues(property, culture, string.Empty, true, _availableLanguages);
+            
             if (indexValues == null || !indexValues.Any()) return new KeyValuePair<string, string>(property.Alias, string.Empty);
 
             var indexValue = indexValues.First();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
@@ -2,7 +2,6 @@
 
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 {
@@ -12,15 +11,11 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 
         private readonly IMediaService _mediaService;
 
-        private readonly IEnumerable<string> _availableLanguages;
-
-        public AlgoliaSearchPropertyIndexValueFactory(IDataTypeService dataTypeService, IMediaService mediaService, ILocalizationService localizationService)
+        public AlgoliaSearchPropertyIndexValueFactory(IDataTypeService dataTypeService, IMediaService mediaService)
         {
             _dataTypeService = dataTypeService;
 
             _mediaService = mediaService;
-
-            _availableLanguages = localizationService.GetAllLanguages().Select(p => p.IsoCode);
 
             Converters = new Dictionary<string, Func<KeyValuePair<string, IEnumerable<object>>, string>>
             {
@@ -30,15 +25,15 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 
         public Dictionary<string, Func<KeyValuePair<string, IEnumerable<object>>, string>> Converters { get; set; }
 
-        public virtual KeyValuePair<string, string> GetValue(IProperty property, string culture)
+        public virtual KeyValuePair<string, string> GetValue(IProperty property, string culture, IEnumerable<string> availableCultures)
         {
             var dataType = _dataTypeService.GetByEditorAlias(property.PropertyType.PropertyEditorAlias)
                 .FirstOrDefault(p => p.Id == property.PropertyType.DataTypeId);
          
             if (dataType == null) return default;
 
-            var indexValues = dataType.Editor.PropertyIndexValueFactory.GetIndexValues(property, culture, string.Empty, true, _availableLanguages);
-            
+            var indexValues = dataType.Editor.PropertyIndexValueFactory.GetIndexValues(property, culture, string.Empty, true, availableCultures);
+
             if (indexValues == null || !indexValues.Any()) return new KeyValuePair<string, string>(property.Alias, string.Empty);
 
             var indexValue = indexValues.First();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/IAlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/IAlgoliaSearchPropertyIndexValueFactory.cs
@@ -11,7 +11,8 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
         /// </summary>
         /// <param name="property"></param>
         /// <param name="culture"></param>
+        /// <param name="availableCultures"></param>
         /// <returns>[alias, value] pair</returns>
-        KeyValuePair<string, string> GetValue(IProperty property, string culture);
+        KeyValuePair<string, string> GetValue(IProperty property, string culture, IEnumerable<string> availableCultures);
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Search.Algolia</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.4.1</Version>
+		<Version>1.5.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
@@ -24,7 +24,7 @@
 	<ItemGroup>
 		<PackageReference Include="Algolia.Search" Version="6.13.0" />
 		<PackageReference Include="Umbraco.Cms.Web.Website" version="[10.3.0,)" />
-		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[10.3.0,)" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[10.6.0,)" />
 		<PackageReference Include="Umbraco.Cms.Web.Common" version="[10.3.0,)" />
 	</ItemGroup>
 	

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -23,9 +23,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Algolia.Search" Version="6.13.0" />
-		<PackageReference Include="Umbraco.Cms.Web.Website" version="[10.3.0,)" />
+		<PackageReference Include="Umbraco.Cms.Web.Website" version="[10.6.0,)" />
 		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[10.6.0,)" />
-		<PackageReference Include="Umbraco.Cms.Web.Common" version="[10.3.0,)" />
+		<PackageReference Include="Umbraco.Cms.Web.Common" version="[10.6.0,)" />
 	</ItemGroup>
 	
 	<ItemGroup>


### PR DESCRIPTION
Current PR fixes issue #124 caused by a method being deprecated in recent versions of Umbraco.

The fix uses the issue reporter's recommendations, but to avoid compile errors, I had to modify the minimum required version of `Umbraco.Cms.Web.BackOffice` to `10.6.0`.