### PR TITLE
Feature/performance update

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/views/dashboard.html
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/views/dashboard.html
@@ -1,8 +1,8 @@
 ﻿<div ng-controller="Umbraco.Cms.Integrations.Search.Algolia.DashboardController as vm">
 
-    <div ng-show="vm.loading">
-        <umb-loading-indicator></umb-loading-indicator>
-    </div>
+  <div ng-show="vm.loading">
+    <umb-loading-indicator>Loading...</umb-loading-indicator>
+  </div>
 
     <uui-box headline="Algolia Indices" ng-if="vm.viewState == 'list'">
         <div>
@@ -55,7 +55,7 @@
                                 <uui-button label="edit" look="default" color="default" ng-click="vm.viewIndex(index)">
                                     <uui-icon name="edit"></uui-icon>
                                 </uui-button>
-                                <uui-button label="build" look="default" color="danger" ng-click="vm.buildIndexConfirm(index)">
+                                <uui-button label="build" look="default" color="danger" ng-click="vm.buildIndexConfirm(index)" ng-disabled="vm.loading">
                                     <uui-icon name="sync"></uui-icon>
                                 </uui-button>
                                 <uui-button label="search" look="default" color="positive" ng-click="vm.searchIndex(index)">

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
@@ -26,7 +26,56 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
 
             _algoliaSearchPropertyIndexValueFactory = algoliaSearchPropertyIndexValueFactory;
         }
+        public ContentRecordBuilder BuildFromContent(IPublishedContent content, Func<IPublishedProperty, bool> filter = null)
+        {
+            _record.ObjectID = content.Key.ToString();
 
+            _record.Id = content.Id;
+            _record.Name = content.Name;
+
+            _record.CreateDate = content.CreateDate.ToString();
+            _record.CreatorName = content.CreatorName();
+            _record.UpdateDate = content.UpdateDate.ToString();
+            _record.WriterName = content.WriterName();
+
+            _record.TemplateId = content.TemplateId.HasValue ? content.TemplateId.Value : -1;
+            _record.Level = content.Level;
+            _record.Path = content.Path;
+            _record.ContentTypeAlias = content.ContentType.Alias;
+            _record.Url = _urlProvider.GetUrl(content.Id);
+
+            if (content.Cultures.Any())
+            {
+                foreach (var culture in content.Cultures)
+                {
+                    _record.Data.Add($"name{(!string.IsNullOrEmpty(culture.Value.Culture) ? "-" + culture.Value.Culture : "")}", culture.Value.Name);
+                    _record.Data.Add($"url{(!string.IsNullOrEmpty(culture.Value.Culture) ? "-" + culture.Value.Culture : "")}", content.Url(culture.Value.Culture));
+                }
+            }
+
+            foreach (var property in content.Properties.Where(filter ?? (p => true)))
+            {
+                if (!_record.Data.ContainsKey(property.Alias))
+                {
+                    if (property.PropertyType.VariesByCulture())
+                    {
+                        foreach (var culture in content.Cultures)
+                        {
+                            var indexValue = _algoliaSearchPropertyIndexValueFactory.GetValue(property, culture.Value.Culture);
+                            _record.Data.Add($"{indexValue.Key}-{culture.Value.Culture}", indexValue.Value);
+                        }
+                    }
+                    else
+                    {
+                        var indexValue = _algoliaSearchPropertyIndexValueFactory.GetValue(property, string.Empty);
+                        _record.Data.Add(indexValue.Key, indexValue.Value);
+                    }
+
+                }
+            }
+
+            return this;
+        }
         public ContentRecordBuilder BuildFromContent(IContent content, Func<IProperty, bool> filter = null)
         {
             _record.ObjectID = content.Key.ToString();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Services
@@ -41,6 +42,21 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
             if (Converters.ContainsKey(property.PropertyType.PropertyEditorAlias))
             {
                 var result = Converters[property.PropertyType.PropertyEditorAlias].Invoke(indexValue);
+                return new KeyValuePair<string, string>(property.Alias, result);
+            }
+
+            return new KeyValuePair<string, string>(indexValue.Key, ParseIndexValue(indexValue.Value));
+        }
+        public virtual KeyValuePair<string, string> GetValue(IPublishedProperty property, string culture)
+        {
+
+            var listOfObjects = new List<object> { property.GetSourceValue(culture) };
+
+            var indexValue = new KeyValuePair<string, IEnumerable<object>>(property.Alias, listOfObjects);
+            
+            if (Converters.ContainsKey(property.PropertyType.EditorAlias))
+            {
+                var result = Converters[property.PropertyType.EditorAlias].Invoke(indexValue);
                 return new KeyValuePair<string, string>(property.Alias, result);
             }
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/IAlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/IAlgoliaSearchPropertyIndexValueFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 {
@@ -13,5 +14,12 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
         /// <param name="culture"></param>
         /// <returns>[alias, value] pair</returns>
         KeyValuePair<string, string> GetValue(IProperty property, string culture);
+        /// <summary>
+        /// Get property indexed value
+        /// </summary>
+        /// <param name="property"></param>
+        /// <param name="culture"></param>
+        /// <returns>[alias, value] pair</returns>
+        KeyValuePair<string, string> GetValue(IPublishedProperty property, string culture);
     }
 }


### PR DESCRIPTION
We had 7000 nodes that we were trying to index into Angolia with out a success.

After looking into the build code we could see that it took 2-3sec to build each record and there for would have taken around 5 hours to finish.

We were working locally and connecting to an azure database. This would make it slower and we understand that it would have been faster on the production machine.

For each record the code was calling GetById into content service and also for each property on that content it would call _dataTypeService.GetByEditorAlias. This would create huge amount of db connection that slows down the process immensly.

We could not see any reason to use content services or any services that connects to the db for this function as we only want published nodes into the Angolia Index.

This update will change it so we only use IPublishedProperty and IPublishedContent instead of the IContent and IProperty.

After this change we could see huge performance difference. each record took 10-20ms instead of 2000-2500ms.
