### PR TITLE
Add Shopify rendering model NULL check

### DIFF
--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/Render/Products.cshtml
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/Render/Products.cshtml
@@ -1,12 +1,15 @@
 ﻿@inherits Umbraco.Web.Mvc.UmbracoViewPage<List<Umbraco.Cms.Integrations.Commerce.Shopify.Models.ViewModels.ProductViewModel>>
 
-<dl class="products-list">
-    @foreach (var product in Model)
-    {
-        <dt class="product-title">@product.Title</dt>
-        <dd class="product-body">@Html.Raw(product.Body)</dd>
-        <img class="product-image" src="@product.Image" alt="@product.Title" />
-    }
-</dl>
+@if (Model != null)
+{
+    <dl class="products-list">
+        @foreach (var product in Model)
+        {
+            <dt class="product-title">@product.Title</dt>
+            <dd class="product-body">@Html.Raw(product.Body)</dd>
+            <img class="product-image" src="@product.Image" alt="@product.Title" />
+        }
+    </dl>
+}
 
 

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/Render/ProductsV9.cshtml
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/Render/ProductsV9.cshtml
@@ -1,13 +1,16 @@
 ﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<List<Umbraco.Cms.Integrations.Commerce.Shopify.Models.ViewModels.ProductViewModel>>
 
-<dl class="products-list">
-    @foreach (var product in Model)
-    {
-        <dt class="product-title">@product.Title</dt>
-        <dd class="product-body">@Html.Raw(product.Body)</dd>
-        <img class="product-image" src="@product.Image" alt="@product.Title" /> 
-    }
-</dl>
+@if (Model != null)
+{
+    <dl class="products-list">
+        @foreach (var product in Model)
+        {
+            <dt class="product-title">@product.Title</dt>
+            <dd class="product-body">@Html.Raw(product.Body)</dd>
+            <img class="product-image" src="@product.Image" alt="@product.Title" />
+        }
+    </dl>
+}
 
 
 

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Umbraco.Cms.Integrations.Commerce.Shopify.csproj
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Umbraco.Cms.Integrations.Commerce.Shopify.csproj
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Commerce.Shopify</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.1.2</Version>
+		<Version>1.1.3</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR contains a fix for the _Shopify_ rendering component by adding a `NULL` check. I came across this while testing [this](https://github.com/umbraco/Umbraco.Cms.Integrations/issues/136) issue.