### PR TITLE
Bugfix/zapier auth fix

### DIFF
--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/ZapierAuthorizedApiController.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Controllers/ZapierAuthorizedApiController.cs
@@ -66,10 +66,7 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Controllers
 
             if (string.IsNullOrEmpty(apiKey) && (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))) return false;
 
-            if (!string.IsNullOrEmpty(apiKey))
-                return apiKey == Options.ApiKey;
-
-            var isAuthorized = _userValidationService.Validate(username, password, Options.ApiKey).GetAwaiter()
+            var isAuthorized = _userValidationService.Validate(username, password, apiKey).GetAwaiter()
                 .GetResult();
             if (!isAuthorized) return false;
 

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/UserValidationService.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/UserValidationService.cs
@@ -72,16 +72,10 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Services
         /// </summary>
         /// <param name="apiKey">Provided API key in the Zap authentication.</param>
         /// <returns></returns>
-        private bool ValidateByApiKey(string apiKey)
-        {
-            // Check API key from CMS settings, if none, check Forms settings
-            if (!string.IsNullOrEmpty(_zapierSettings.ApiKey))
-                return apiKey == _zapierSettings.ApiKey;
-            else if (!string.IsNullOrEmpty(_zapierFormsSettings.ApiKey))
-                return apiKey == _zapierFormsSettings.ApiKey;
-
-            return false;
-        }
+        private bool ValidateByApiKey(string apiKey) =>
+            // Check API key from CMS and Forms settings. 
+            (!string.IsNullOrEmpty(_zapierSettings.ApiKey) && _zapierSettings.ApiKey == apiKey)
+                || (!string.IsNullOrEmpty(_zapierFormsSettings.ApiKey) && _zapierFormsSettings.ApiKey == apiKey);
 
         /// <summary>
         /// Validates user based on provided credentials.

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Umbraco.Cms.Integrations.Automation.Zapier.csproj
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Umbraco.Cms.Integrations.Automation.Zapier.csproj
@@ -9,7 +9,7 @@
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Automation.Zapier</PackageProjectUrl>
 		<Product>Umbraco.Cms.Integrations.Automation.Zapier</Product>
-		<Version>1.3.0</Version>
+		<Version>1.2.1</Version>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
 		<PackageIcon>zapier.png</PackageIcon>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Umbraco.Cms.Integrations.Automation.Zapier.csproj
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Umbraco.Cms.Integrations.Automation.Zapier.csproj
@@ -9,7 +9,7 @@
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Automation.Zapier</PackageProjectUrl>
 		<Product>Umbraco.Cms.Integrations.Automation.Zapier</Product>
-		<Version>1.2.0</Version>
+		<Version>1.3.0</Version>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
 		<PackageIcon>zapier.png</PackageIcon>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>


### PR DESCRIPTION
Current PR adds a fix to the API key based validation flow, based on this Forms package issue reported on Zapier's developer platform:
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/95346674/0a060fb8-e7c3-454a-844f-b7a4a3592e3a)
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/95346674/ca1abe51-ab15-4cc8-90c0-1c7e5d6e630d)
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/95346674/31fd1cc3-7e5d-4574-af65-4b38056cbc28)

Test case to replicate the issue:
1. Have API key for both CMS and Forms
2. Create a new Zap -> user is authenticated with CMS key
3. Select `New form submitted` trigger
4. Pull forms step returns an empty list, because the saved key from step 2. is CMS, and Forms package expects one for Forms.

To fix the issue, I am checking both CMS and Forms keys and validate both.
