### PR TITLE
#151 Added support of non-string field values for indexing

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Models
     {
         public Record()
         {
-            Data = new Dictionary<string, string>();
+            Data = new Dictionary<string, object>();
         }
 
         public string ObjectID { get; set; }
@@ -33,6 +33,6 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Models
 
         public string Url { get; set; }
 
-        public Dictionary<string, string> Data { get; set; }
+        public Dictionary<string, object> Data { get; set; }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaIndexService.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaIndexService.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
                     : new List<Record> {
                         new Record {
                             ObjectID = Guid.NewGuid().ToString(),
-                            Data = new Dictionary<string, string>()}
+                            Data = new Dictionary<string, object>()}
                     }, autoGenerateObjectId: false);
 
                 if (payload == null)

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
@@ -18,15 +18,15 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 
             _mediaService = mediaService;
 
-            Converters = new Dictionary<string, Func<KeyValuePair<string, IEnumerable<object>>, string>>
+            Converters = new Dictionary<string, Func<KeyValuePair<string, IEnumerable<object>>, object>>
             {
                 {  Core.Constants.PropertyEditors.Aliases.MediaPicker3, ConvertMediaPicker }
             };
         }
 
-        public Dictionary<string, Func<KeyValuePair<string, IEnumerable<object>>, string>> Converters { get; set; }
+        public Dictionary<string, Func<KeyValuePair<string, IEnumerable<object>>, object>> Converters { get; set; }
 
-        public virtual KeyValuePair<string, string> GetValue(IProperty property, string culture)
+        public virtual KeyValuePair<string, object> GetValue(IProperty property, string culture)
         {
             var dataType = _dataTypeService.GetByEditorAlias(property.PropertyType.PropertyEditorAlias)
                 .FirstOrDefault(p => p.Id == property.PropertyType.DataTypeId);
@@ -35,19 +35,19 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 
             var indexValues = dataType.Editor.PropertyIndexValueFactory.GetIndexValues(property, culture, string.Empty, true);
 
-            if (indexValues == null || !indexValues.Any()) return new KeyValuePair<string, string>(property.Alias, string.Empty);
+            if (indexValues == null || !indexValues.Any()) return new KeyValuePair<string, object>(property.Alias, string.Empty);
 
             var indexValue = indexValues.First();
 
             if (Converters.ContainsKey(property.PropertyType.PropertyEditorAlias))
             {
                 var result = Converters[property.PropertyType.PropertyEditorAlias].Invoke(indexValue);
-                return new KeyValuePair<string, string>(property.Alias, result);
+                return new KeyValuePair<string, object>(property.Alias, result);
             }
 
-            return new KeyValuePair<string, string>(indexValue.Key, ParseIndexValue(indexValue.Value));
+            return new KeyValuePair<string, object>(indexValue.Key, ParseIndexValue(indexValue.Value));
         }
-        public virtual KeyValuePair<string, string> GetValue(IPublishedProperty property, string culture)
+        public virtual KeyValuePair<string, object> GetValue(IPublishedProperty property, string culture)
         {
 
             var listOfObjects = new List<object> { property.GetSourceValue(culture) };
@@ -57,10 +57,10 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
             if (Converters.ContainsKey(property.PropertyType.EditorAlias))
             {
                 var result = Converters[property.PropertyType.EditorAlias].Invoke(indexValue);
-                return new KeyValuePair<string, string>(property.Alias, result);
+                return new KeyValuePair<string, object>(property.Alias, result);
             }
 
-            return new KeyValuePair<string, string>(indexValue.Key, ParseIndexValue(indexValue.Value));
+            return new KeyValuePair<string, object>(indexValue.Key, ParseIndexValue(indexValue.Value));
         }
 
         public string ParseIndexValue(IEnumerable<object> values)
@@ -77,7 +77,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
             return string.Empty;
         }
 
-        private string ConvertMediaPicker(KeyValuePair<string, IEnumerable<object>> indexValue)
+        private object ConvertMediaPicker(KeyValuePair<string, IEnumerable<object>> indexValue)
         {
             var list = new List<string>();
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/IAlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/IAlgoliaSearchPropertyIndexValueFactory.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 {
     public interface IAlgoliaSearchPropertyIndexValueFactory
     {
-        Dictionary<string, Func<KeyValuePair<string, IEnumerable<object>>, string>> Converters { get; set; }
+        Dictionary<string, Func<KeyValuePair<string, IEnumerable<object>>, object>> Converters { get; set; }
         
         /// <summary>
         /// Get property indexed value
@@ -13,13 +13,13 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
         /// <param name="property"></param>
         /// <param name="culture"></param>
         /// <returns>[alias, value] pair</returns>
-        KeyValuePair<string, string> GetValue(IProperty property, string culture);
+        KeyValuePair<string, object> GetValue(IProperty property, string culture);
         /// <summary>
         /// Get property indexed value
         /// </summary>
         /// <param name="property"></param>
         /// <param name="culture"></param>
         /// <returns>[alias, value] pair</returns>
-        KeyValuePair<string, string> GetValue(IPublishedProperty property, string culture);
+        KeyValuePair<string, object> GetValue(IPublishedProperty property, string culture);
     }
 }


### PR DESCRIPTION
This is to support indexing of non-string values as described in the issue #151. All logic defined in the method `GetValue()` stays the same, but now it allows to create a custom implementation of `IAlgoliaSearchPropertyIndexValueFactory` and push object values to Algolia if necessary.

Before:
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/4091048/62f63af9-7cce-4e09-814a-5482628c595a)

After:
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/4091048/1f2e4816-59d2-4585-9d22-88d5621362a5)
