### PR TITLE
Fix for retrieval of content by type when rebuilding Algolia index and blocks list value getter

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
@@ -26,56 +26,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
 
             _algoliaSearchPropertyIndexValueFactory = algoliaSearchPropertyIndexValueFactory;
         }
-        public ContentRecordBuilder BuildFromContent(IPublishedContent content, Func<IPublishedProperty, bool> filter = null)
-        {
-            _record.ObjectID = content.Key.ToString();
 
-            _record.Id = content.Id;
-            _record.Name = content.Name;
-
-            _record.CreateDate = content.CreateDate.ToString();
-            _record.CreatorName = content.CreatorName();
-            _record.UpdateDate = content.UpdateDate.ToString();
-            _record.WriterName = content.WriterName();
-
-            _record.TemplateId = content.TemplateId.HasValue ? content.TemplateId.Value : -1;
-            _record.Level = content.Level;
-            _record.Path = content.Path;
-            _record.ContentTypeAlias = content.ContentType.Alias;
-            _record.Url = _urlProvider.GetUrl(content.Id);
-
-            if (content.Cultures.Any())
-            {
-                foreach (var culture in content.Cultures)
-                {
-                    _record.Data.Add($"name{(!string.IsNullOrEmpty(culture.Value.Culture) ? "-" + culture.Value.Culture : "")}", culture.Value.Name);
-                    _record.Data.Add($"url{(!string.IsNullOrEmpty(culture.Value.Culture) ? "-" + culture.Value.Culture : "")}", content.Url(culture.Value.Culture));
-                }
-            }
-
-            foreach (var property in content.Properties.Where(filter ?? (p => true)))
-            {
-                if (!_record.Data.ContainsKey(property.Alias))
-                {
-                    if (property.PropertyType.VariesByCulture())
-                    {
-                        foreach (var culture in content.Cultures)
-                        {
-                            var indexValue = _algoliaSearchPropertyIndexValueFactory.GetValue(property, culture.Value.Culture);
-                            _record.Data.Add($"{indexValue.Key}-{culture.Value.Culture}", indexValue.Value);
-                        }
-                    }
-                    else
-                    {
-                        var indexValue = _algoliaSearchPropertyIndexValueFactory.GetValue(property, string.Empty);
-                        _record.Data.Add(indexValue.Key, indexValue.Value);
-                    }
-
-                }
-            }
-
-            return this;
-        }
         public ContentRecordBuilder BuildFromContent(IContent content, Func<IProperty, bool> filter = null)
         {
             _record.ObjectID = content.Key.ToString();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Controllers/SearchController.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Controllers/SearchController.cs
@@ -1,22 +1,18 @@
-﻿using System.Diagnostics;
-using Algolia.Search.Models.Search;
+﻿using Algolia.Search.Models.Search;
 
 using Microsoft.AspNetCore.Mvc;
 
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using Umbraco.Cms.Core.Routing;
-using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Services.Implement;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Integrations.Search.Algolia.Builders;
 using Umbraco.Cms.Integrations.Search.Algolia.Migrations;
 using Umbraco.Cms.Integrations.Search.Algolia.Models;
 using Umbraco.Cms.Integrations.Search.Algolia.Services;
 using Umbraco.Cms.Web.BackOffice.Controllers;
-using Umbraco.Cms.Web.Common;
 using Umbraco.Cms.Web.Common.Attributes;
-using Umbraco.Extensions;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Controllers
 {
@@ -28,8 +24,6 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Controllers
         private readonly IAlgoliaSearchService<SearchResponse<Record>> _searchService;
 
         private readonly IAlgoliaIndexDefinitionStorage<AlgoliaIndex> _indexStorage;
-
-        private readonly UmbracoHelper _umbracoHelper;
 
         private readonly IUserService _userService;
 
@@ -47,7 +41,6 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Controllers
             IAlgoliaIndexService indexService, 
             IAlgoliaSearchService<SearchResponse<Record>> searchService, 
             IAlgoliaIndexDefinitionStorage<AlgoliaIndex> indexStorage,
-            UmbracoHelper umbracoHelper, 
             IUserService userService,
             IPublishedUrlProvider urlProvider,
             IContentService contentService,
@@ -60,8 +53,6 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Controllers
             _searchService = searchService;
 
             _indexStorage = indexStorage;
-
-            _umbracoHelper = umbracoHelper;
 
             _userService = userService;
 
@@ -130,7 +121,8 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Controllers
                 {
                     using var ctx = _umbracoContextFactory.EnsureUmbracoContext();
                     var contentType = ctx.UmbracoContext.Content.GetContentType(contentDataItem.ContentType.Alias);
-                    var contentItems = ctx.UmbracoContext.Content.GetByContentType(contentType);
+
+                    var contentItems = _contentService.GetPagedOfType(contentType.Id, 0, int.MaxValue, out _, null);
 
                     _logger.LogInformation("Building index for {ContentType} with {Count} items", contentDataItem.ContentType.Alias, contentItems.Count());
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/IAlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/IAlgoliaSearchPropertyIndexValueFactory.cs
@@ -1,5 +1,4 @@
 ﻿using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 {
@@ -14,12 +13,5 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
         /// <param name="culture"></param>
         /// <returns>[alias, value] pair</returns>
         KeyValuePair<string, string> GetValue(IProperty property, string culture);
-        /// <summary>
-        /// Get property indexed value
-        /// </summary>
-        /// <param name="property"></param>
-        /// <param name="culture"></param>
-        /// <returns>[alias, value] pair</returns>
-        KeyValuePair<string, string> GetValue(IPublishedProperty property, string culture);
     }
 }


### PR DESCRIPTION
The current code that is getting a list of content by type is not (always) working, this is an Umbraco bug which causes the following call: `var contentItems = ctx.UmbracoContext.Content.GetByContentType(contentType)` to return an empty list for some content types (as far as I know, it is connected to types that are composed of other types). In order to avoid this problem, I switched to using `GetPagedOfType` from `ContentService`. 

As a side effect, since the new code makes use of `IContent` and not `IPublishedContent`, we can remove the extra code that was added in this PR: https://github.com/umbraco/Umbraco.Cms.Integrations/pull/140 by @gardarthorsteins 

It is also worth mentioning that the removed code had an extra bug in `AlgoliaSearchPropertyIndexValueFactory`'s `KeyValuePair<string, string> GetValue(IPublishedProperty property, string culture)`: it used `property.GetSourceValue(culture)` in order to get a value to index but as contrary to `GetIndexValues` from `IPropertyIndexValueFactory`, it did not return correct data to index for the data type of `Umbraco.BlockList` which is another reason to get rid of the new method of `GetValue` for `IPublishedProperty`. Additionally, the method introduced some code duplication.

As the mentioned PR from @gardarthorsteins attempted to fix performance issues, the new version is handling them by making use of an injected `PropertyEditorCollection` in `AlgoliaSearchPropertyIndexValueFactory` so there is no need to make multiple calls for data types and their editors from `IDataTypeService`. I tested the performance on indexing over 9000 nodes which is taking on average 12 seconds on my local machine so around 1.3 millisecond for entry