### PR TITLE
Implement Algolia converter collection builder.

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/AlgoliaComposer.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/AlgoliaComposer.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign
 
             builder.AddNotificationAsyncHandler<ContentCacheRefresherNotification, AlgoliaContentCacheRefresherHandler>();
             
-            _ = builder.Services.AddOptions<AlgoliaSettings>()
+           builder.Services.AddOptions<AlgoliaSettings>()
                 .Bind(builder.Config.GetSection(Constants.SettingsPath));
 
             builder.Services.AddSingleton<IAlgoliaIndexService, AlgoliaIndexService>();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/AlgoliaComposer.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/AlgoliaComposer.cs
@@ -7,6 +7,7 @@ using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Integrations.Search.Algolia;
 using Umbraco.Cms.Integrations.Search.Algolia.Configuration;
+using Umbraco.Cms.Integrations.Search.Algolia.Extensions;
 using Umbraco.Cms.Integrations.Search.Algolia.Handlers;
 using Umbraco.Cms.Integrations.Search.Algolia.Migrations;
 using Umbraco.Cms.Integrations.Search.Algolia.Models;
@@ -21,8 +22,8 @@ namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign
             builder.AddNotificationHandler<UmbracoApplicationStartingNotification, RunAlgoliaIndicesMigration>();
 
             builder.AddNotificationAsyncHandler<ContentCacheRefresherNotification, AlgoliaContentCacheRefresherHandler>();
-
-            var options = builder.Services.AddOptions<AlgoliaSettings>()
+            
+            _ = builder.Services.AddOptions<AlgoliaSettings>()
                 .Bind(builder.Config.GetSection(Constants.SettingsPath));
 
             builder.Services.AddSingleton<IAlgoliaIndexService, AlgoliaIndexService>();
@@ -32,6 +33,8 @@ namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign
             builder.Services.AddScoped<IAlgoliaIndexDefinitionStorage<AlgoliaIndex>, AlgoliaIndexDefinitionStorage>();
 
             builder.Services.AddScoped<IAlgoliaSearchPropertyIndexValueFactory, AlgoliaSearchPropertyIndexValueFactory>();
+
+            builder.AddAlgoliaConverters();
         }
 
     }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
@@ -26,56 +26,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
 
             _algoliaSearchPropertyIndexValueFactory = algoliaSearchPropertyIndexValueFactory;
         }
-        public ContentRecordBuilder BuildFromContent(IPublishedContent content, Func<IPublishedProperty, bool> filter = null)
-        {
-            _record.ObjectID = content.Key.ToString();
 
-            _record.Id = content.Id;
-            _record.Name = content.Name;
-
-            _record.CreateDate = content.CreateDate.ToString();
-            _record.CreatorName = content.CreatorName();
-            _record.UpdateDate = content.UpdateDate.ToString();
-            _record.WriterName = content.WriterName();
-
-            _record.TemplateId = content.TemplateId.HasValue ? content.TemplateId.Value : -1;
-            _record.Level = content.Level;
-            _record.Path = content.Path;
-            _record.ContentTypeAlias = content.ContentType.Alias;
-            _record.Url = _urlProvider.GetUrl(content.Id);
-
-            if (content.Cultures.Any())
-            {
-                foreach (var culture in content.Cultures)
-                {
-                    _record.Data.Add($"name{(!string.IsNullOrEmpty(culture.Value.Culture) ? "-" + culture.Value.Culture : "")}", culture.Value.Name);
-                    _record.Data.Add($"url{(!string.IsNullOrEmpty(culture.Value.Culture) ? "-" + culture.Value.Culture : "")}", content.Url(culture.Value.Culture));
-                }
-            }
-
-            foreach (var property in content.Properties.Where(filter ?? (p => true)))
-            {
-                if (!_record.Data.ContainsKey(property.Alias))
-                {
-                    if (property.PropertyType.VariesByCulture())
-                    {
-                        foreach (var culture in content.Cultures)
-                        {
-                            var indexValue = _algoliaSearchPropertyIndexValueFactory.GetValue(property, culture.Value.Culture);
-                            _record.Data.Add($"{indexValue.Key}-{culture.Value.Culture}", indexValue.Value);
-                        }
-                    }
-                    else
-                    {
-                        var indexValue = _algoliaSearchPropertyIndexValueFactory.GetValue(property, string.Empty);
-                        _record.Data.Add(indexValue.Key, indexValue.Value);
-                    }
-
-                }
-            }
-
-            return this;
-        }
         public ContentRecordBuilder BuildFromContent(IContent content, Func<IProperty, bool> filter = null)
         {
             _record.ObjectID = content.Key.ToString();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Controllers/SearchController.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Controllers/SearchController.cs
@@ -134,7 +134,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Controllers
 
                     _logger.LogInformation("Building index for {ContentType} with {Count} items", contentDataItem.ContentType.Alias, contentItems.Count());
 
-                    foreach (var contentItem in contentItems)
+                    foreach (var contentItem in contentItems.Where(p => !p.Trashed))
                     {
                         var record = new ContentRecordBuilder(_userService, _urlProvider, _algoliaSearchPropertyIndexValueFactory)
                             .BuildFromContent(contentItem, (p) => contentDataItem.Properties.Any(q => q.Alias == p.Alias))

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Controllers/SearchController.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Controllers/SearchController.cs
@@ -130,7 +130,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Controllers
                 {
                     using var ctx = _umbracoContextFactory.EnsureUmbracoContext();
                     var contentType = ctx.UmbracoContext.Content.GetContentType(contentDataItem.ContentType.Alias);
-                    var contentItems = ctx.UmbracoContext.Content.GetByContentType(contentType);
+                    var contentItems = _contentService.GetPagedOfType(contentType.Id, 0, int.MaxValue, out _, null);
 
                     _logger.LogInformation("Building index for {ContentType} with {Count} items", contentDataItem.ContentType.Alias, contentItems.Count());
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/IAlgoliaIndexValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/IAlgoliaIndexValueConverter.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Defines a custom index converter.
     /// </summary>
-    public interface IConverter
+    public interface IAlgoliaIndexValueConverter
     {
         /// <summary>
         /// Gets the name of the converter.
@@ -11,8 +11,8 @@
         string Name { get; }
 
         /// <summary>
-        /// Parses the index value.
+        /// Parses the index values.
         /// </summary>
-        object ParseIndexValue(KeyValuePair<string, IEnumerable<object>> indexValue);
+        object ParseIndexValues(IEnumerable<object> indexValues);
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/IConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/IConverter.cs
@@ -1,0 +1,18 @@
+﻿namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
+{
+    /// <summary>
+    /// Defines a custom index converter.
+    /// </summary>
+    public interface IConverter
+    {
+        /// <summary>
+        /// Gets the name of the converter.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Parses the index value.
+        /// </summary>
+        object ParseIndexValue(KeyValuePair<string, IEnumerable<object>> indexValue);
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoBooleanConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoBooleanConverter.cs
@@ -1,0 +1,21 @@
+﻿namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
+{
+    public class UmbracoBooleanConverter : IConverter
+    {
+        public string Name => Core.Constants.PropertyEditors.Aliases.Boolean;
+
+        public object ParseIndexValue(KeyValuePair<string, IEnumerable<object>> indexValue)
+        {
+            if (indexValue.Value != null && indexValue.Value.Any())
+            {
+                var value = indexValue.Value.FirstOrDefault();
+
+                return value != null
+                    ? value.Equals(1)
+                    : default;
+            }
+
+            return default(bool);
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoBooleanConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoBooleanConverter.cs
@@ -1,14 +1,14 @@
 ﻿namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
-    public class UmbracoBooleanConverter : IConverter
+    public class UmbracoBooleanConverter : IAlgoliaIndexValueConverter
     {
         public string Name => Core.Constants.PropertyEditors.Aliases.Boolean;
 
-        public object ParseIndexValue(KeyValuePair<string, IEnumerable<object>> indexValue)
+        public object ParseIndexValues(IEnumerable<object> indexValues)
         {
-            if (indexValue.Value != null && indexValue.Value.Any())
+            if (indexValues != null && indexValues.Any())
             {
-                var value = indexValue.Value.FirstOrDefault();
+                var value = indexValues.FirstOrDefault();
 
                 return value != null
                     ? value.Equals(1)

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoDecimalConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoDecimalConverter.cs
@@ -1,14 +1,14 @@
 ﻿namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
-    public class UmbracoDecimalConverter : IConverter
+    public class UmbracoDecimalConverter : IAlgoliaIndexValueConverter
     {
         public string Name => Core.Constants.PropertyEditors.Aliases.Decimal;
 
-        public object ParseIndexValue(KeyValuePair<string, IEnumerable<object>> indexValue)
+        public object ParseIndexValues(IEnumerable<object> indexValues)
         {
-            if (indexValue.Value != null && indexValue.Value.Any())
+            if (indexValues != null && indexValues.Any())
             {
-                var value = indexValue.Value.FirstOrDefault();
+                var value = indexValues.FirstOrDefault();
 
                 return value != null
                     ? decimal.Parse(value.ToString())

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoDecimalConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoDecimalConverter.cs
@@ -1,0 +1,21 @@
+﻿namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
+{
+    public class UmbracoDecimalConverter : IConverter
+    {
+        public string Name => Core.Constants.PropertyEditors.Aliases.Decimal;
+
+        public object ParseIndexValue(KeyValuePair<string, IEnumerable<object>> indexValue)
+        {
+            if (indexValue.Value != null && indexValue.Value.Any())
+            {
+                var value = indexValue.Value.FirstOrDefault();
+
+                return value != null
+                    ? decimal.Parse(value.ToString())
+                    : default;
+            }
+
+            return default(decimal);
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoIntegerConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoIntegerConverter.cs
@@ -1,0 +1,21 @@
+﻿using System.Windows.Markup;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
+{
+    public class UmbracoIntegerConverter : IConverter
+    {
+        public string Name => Core.Constants.PropertyEditors.Aliases.Integer;
+
+        public object ParseIndexValue(KeyValuePair<string, IEnumerable<object>> indexValue)
+        {
+            if (indexValue.Value != null && indexValue.Value.Any())
+            {
+                var value = indexValue.Value.FirstOrDefault();
+
+                return value ?? default(int);
+            }
+
+            return default(int);
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoIntegerConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoIntegerConverter.cs
@@ -1,16 +1,14 @@
-﻿using System.Windows.Markup;
-
-namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
+﻿namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
-    public class UmbracoIntegerConverter : IConverter
+    public class UmbracoIntegerConverter : IAlgoliaIndexValueConverter
     {
         public string Name => Core.Constants.PropertyEditors.Aliases.Integer;
 
-        public object ParseIndexValue(KeyValuePair<string, IEnumerable<object>> indexValue)
+        public object ParseIndexValues(IEnumerable<object> indexValues)
         {
-            if (indexValue.Value != null && indexValue.Value.Any())
+            if (indexValues != null && indexValues.Any())
             {
-                var value = indexValue.Value.FirstOrDefault();
+                var value = indexValues.FirstOrDefault();
 
                 return value ?? default(int);
             }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoMediaPickerConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoMediaPickerConverter.cs
@@ -1,0 +1,54 @@
+﻿using System.Text.Json;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
+{
+    public class UmbracoMediaPickerConverter : IConverter
+    {
+        private readonly IMediaService _mediaService;
+
+        public UmbracoMediaPickerConverter(IMediaService mediaService) => _mediaService = mediaService;
+
+        public string Name => Core.Constants.PropertyEditors.Aliases.MediaPicker3;
+
+        public object ParseIndexValue(KeyValuePair<string, IEnumerable<object>> indexValue)
+        {
+            var list = new List<string>();
+
+            var parsedIndexValue = ParseIndexValue(indexValue.Value);
+
+            if (string.IsNullOrEmpty(parsedIndexValue)) return list;
+
+            var inputMedia = JsonSerializer.Deserialize<IEnumerable<MediaItem>>(parsedIndexValue);
+
+            if (inputMedia == null) return string.Empty;
+
+            foreach (var item in inputMedia)
+            {
+                if (item == null) continue;
+
+                var mediaItem = _mediaService.GetById(Guid.Parse(item.MediaKey));
+
+                if (mediaItem == null) continue;
+
+                list.Add(mediaItem.GetValue("umbracoFile")?.ToString() ?? string.Empty);
+            }
+
+            return list;
+        }
+
+        private string ParseIndexValue(IEnumerable<object> values)
+        {
+            if (values != null && values.Any())
+            {
+                var value = values.FirstOrDefault();
+
+                if (value == null) return string.Empty;
+
+                return value.ToString();
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoMediaPickerConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoMediaPickerConverter.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
-    public class UmbracoMediaPickerConverter : IConverter
+    public class UmbracoMediaPickerConverter : IAlgoliaIndexValueConverter
     {
         private readonly IMediaService _mediaService;
 
@@ -11,11 +11,11 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 
         public string Name => Core.Constants.PropertyEditors.Aliases.MediaPicker3;
 
-        public object ParseIndexValue(KeyValuePair<string, IEnumerable<object>> indexValue)
+        public object ParseIndexValues(IEnumerable<object> indexValues)
         {
             var list = new List<string>();
 
-            var parsedIndexValue = ParseIndexValue(indexValue.Value);
+            var parsedIndexValue = ParseIndexValue(indexValues);
 
             if (string.IsNullOrEmpty(parsedIndexValue)) return list;
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoTagsConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoTagsConverter.cs
@@ -2,15 +2,15 @@
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
-    public class UmbracoTagsConverter : IConverter
+    public class UmbracoTagsConverter : IAlgoliaIndexValueConverter
     {
         public string Name => Core.Constants.PropertyEditors.Aliases.Tags;
 
-        public object ParseIndexValue(KeyValuePair<string, IEnumerable<object>> indexValue)
+        public object ParseIndexValues(IEnumerable<object> indexValues)
         {
-            if (indexValue.Value != null && indexValue.Value.Any())
+            if (indexValues != null && indexValues.Any())
             {
-                return indexValue.Value;
+                return indexValues;
             }
 
             return Enumerable.Empty<string>();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoTagsConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoTagsConverter.cs
@@ -1,0 +1,19 @@
+﻿using System.Text.Json;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
+{
+    public class UmbracoTagsConverter : IConverter
+    {
+        public string Name => Core.Constants.PropertyEditors.Aliases.Tags;
+
+        public object ParseIndexValue(KeyValuePair<string, IEnumerable<object>> indexValue)
+        {
+            if (indexValue.Value != null && indexValue.Value.Any())
+            {
+                return indexValue.Value;
+            }
+
+            return Enumerable.Empty<string>();
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Extensions/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Extensions/UmbracoBuilderExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Integrations.Search.Algolia.Converters;
+using Umbraco.Cms.Integrations.Search.Algolia.Providers;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Extensions
+{
+    public static class UmbracoBuilderExtensions
+    {
+        public static IUmbracoBuilder AddAlgoliaConverters(this IUmbracoBuilder builder)
+        {
+            builder.AlgoliaConverters()
+                .Append<UmbracoMediaPickerConverter>()
+                .Append<UmbracoDecimalConverter>()
+                .Append<UmbracoIntegerConverter>()
+                .Append<UmbracoBooleanConverter>()
+                .Append<UmbracoTagsConverter>();
+
+            return builder;
+        }
+
+        public static ConverterCollectionBuilder AlgoliaConverters(this IUmbracoBuilder builder)
+            => builder.WithCollectionBuilder<ConverterCollectionBuilder>();
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Models
     {
         public Record()
         {
-            Data = new Dictionary<string, string>();
+            Data = new Dictionary<string, object>();
         }
 
         public string ObjectID { get; set; }
@@ -33,6 +33,6 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Models
 
         public string Url { get; set; }
 
-        public Dictionary<string, string> Data { get; set; }
+        public Dictionary<string, object> Data { get; set; }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Providers/ConverterCollection.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Providers/ConverterCollection.cs
@@ -3,9 +3,9 @@ using Umbraco.Cms.Integrations.Search.Algolia.Converters;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Providers
 {
-    public class ConverterCollection : BuilderCollectionBase<IConverter>
+    public class ConverterCollection : BuilderCollectionBase<IAlgoliaIndexValueConverter>
     {
-        public ConverterCollection(Func<IEnumerable<IConverter>> items)
+        public ConverterCollection(Func<IEnumerable<IAlgoliaIndexValueConverter>> items)
             : base(items) 
         { 
         }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Providers/ConverterCollection.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Providers/ConverterCollection.cs
@@ -1,0 +1,13 @@
+﻿using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Integrations.Search.Algolia.Converters;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Providers
+{
+    public class ConverterCollection : BuilderCollectionBase<IConverter>
+    {
+        public ConverterCollection(Func<IEnumerable<IConverter>> items)
+            : base(items) 
+        { 
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Providers/ConverterCollectionBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Providers/ConverterCollectionBuilder.cs
@@ -1,0 +1,10 @@
+﻿using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Integrations.Search.Algolia.Converters;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Providers
+{
+    public class ConverterCollectionBuilder : OrderedCollectionBuilderBase<ConverterCollectionBuilder, ConverterCollection, IConverter>
+    {
+        protected override ConverterCollectionBuilder This => this;
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Providers/ConverterCollectionBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Providers/ConverterCollectionBuilder.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Integrations.Search.Algolia.Converters;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Providers
 {
-    public class ConverterCollectionBuilder : OrderedCollectionBuilderBase<ConverterCollectionBuilder, ConverterCollection, IConverter>
+    public class ConverterCollectionBuilder : OrderedCollectionBuilderBase<ConverterCollectionBuilder, ConverterCollection, IAlgoliaIndexValueConverter>
     {
         protected override ConverterCollectionBuilder This => this;
     }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaIndexService.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaIndexService.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
                     : new List<Record> {
                         new Record {
                             ObjectID = Guid.NewGuid().ToString(),
-                            Data = new Dictionary<string, string>()}
+                            Data = new Dictionary<string, object>()}
                     }, autoGenerateObjectId: false);
 
                 if (payload == null)

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
@@ -37,11 +37,11 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
             var converter = _converterCollection.FirstOrDefault(p => p.Name == property.PropertyType.PropertyEditorAlias);
             if (converter != null)
             {
-                var result = converter.ParseIndexValue(indexValue);
+                var result = converter.ParseIndexValues(indexValue.Value);
                 return new KeyValuePair<string, object>(property.Alias, result);
             }
 
-            return new KeyValuePair<string, object>(indexValue.Key, indexValue.Value);
+            return new KeyValuePair<string, object>(property.Alias, indexValue.Value);
         }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/IAlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/IAlgoliaSearchPropertyIndexValueFactory.cs
@@ -1,25 +1,15 @@
 ﻿using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 {
     public interface IAlgoliaSearchPropertyIndexValueFactory
     {
-        Dictionary<string, Func<KeyValuePair<string, IEnumerable<object>>, string>> Converters { get; set; }
-        
         /// <summary>
         /// Get property indexed value
         /// </summary>
         /// <param name="property"></param>
         /// <param name="culture"></param>
         /// <returns>[alias, value] pair</returns>
-        KeyValuePair<string, string> GetValue(IProperty property, string culture);
-        /// <summary>
-        /// Get property indexed value
-        /// </summary>
-        /// <param name="property"></param>
-        /// <param name="culture"></param>
-        /// <returns>[alias, value] pair</returns>
-        KeyValuePair<string, string> GetValue(IPublishedProperty property, string culture);
+        KeyValuePair<string, object> GetValue(IProperty property, string culture);
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Search.Algolia</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.6.0</Version>
+		<Version>2.0.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Search.Algolia</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.5.0</Version>
+		<Version>1.6.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR contains the refactoring of converters using the existing `CMS` and `Forms` collection builders, allowing developers to append their own custom converters for _Algolia_, or to replace one of the default five converters I've added.

The current default converters are intended for the following Umbraco property editors:
- `Umbraco.TrueFalse`
- `Umbraco.Decimal`
- `Umbraco.Integer`
- `Umbraco.MediaPicker3`
- `Umbraco.Tags`

To create a new converter one should implement the `IConverter` interface, specify the name of the property editor and add the new implementation. Then the new converter will need to be added to the `Algolia Converters` collection.

For example (this will be added to the docs aswell), to remove the existing tags converter, I will ...
1. Create the converter
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/95346674/c7b59b10-199a-4af6-be1f-730816f08c84)

2. Replace existing converter with the new one
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/95346674/fb61fd3e-534d-4983-9c72-6ec64b8ff463)

3. Inject custom converters
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/95346674/0acd4ee7-3025-4ef7-9a5d-dea9e7df19d7)

With this update, I have also addressed these issues:
- #151 
- #150 
- #149 (picked some of the recommendations from this PR #153 )