### PR TITLE
Possibility to add custom record values in Algolia index

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/AlgoliaComposer.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/AlgoliaComposer.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Integrations.Search.Algolia;
+using Umbraco.Cms.Integrations.Search.Algolia.Builders;
 using Umbraco.Cms.Integrations.Search.Algolia.Configuration;
 using Umbraco.Cms.Integrations.Search.Algolia.Extensions;
 using Umbraco.Cms.Integrations.Search.Algolia.Handlers;
@@ -31,6 +32,8 @@ namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign
             builder.Services.AddSingleton<IAlgoliaSearchService<SearchResponse<Record>>, AlgoliaSearchService>();
 
             builder.Services.AddScoped<IAlgoliaIndexDefinitionStorage<AlgoliaIndex>, AlgoliaIndexDefinitionStorage>();
+
+            builder.Services.AddScoped<IRecordBuilderFactory, RecordBuilderFactory>();
 
             builder.Services.AddScoped<IAlgoliaSearchPropertyIndexValueFactory, AlgoliaSearchPropertyIndexValueFactory>();
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/IRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/IRecordBuilder.cs
@@ -1,0 +1,16 @@
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Integrations.Search.Algolia.Models;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
+{
+    public interface IRecordBuilder
+    {
+        Record GetRecord(IContent content, Record record);
+    }
+
+    public interface IRecordBuilder<in TContentType> 
+        : IRecordBuilder where TContentType : PublishedContentModel 
+    {
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/IRecordBuilderFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/IRecordBuilderFactory.cs
@@ -1,0 +1,9 @@
+﻿using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
+{
+    public interface IRecordBuilderFactory
+    {
+        IRecordBuilder GetRecordBuilderService(IContent content);
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/RecordBuilderFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/RecordBuilderFactory.cs
@@ -1,0 +1,50 @@
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Web;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
+{
+    public class RecordBuilderFactory : IRecordBuilderFactory
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        private readonly IUmbracoContextFactory _umbracoContextFactory;
+
+        private readonly IDictionary<string, Type> _recordBuilderCache = new Dictionary<string, Type>();
+
+        public RecordBuilderFactory(IServiceProvider serviceProvider, IUmbracoContextFactory umbracoContextFactory)
+        {
+            _serviceProvider = serviceProvider;
+            _umbracoContextFactory = umbracoContextFactory;
+        }
+
+        public IRecordBuilder GetRecordBuilderService(IContent content)
+        {
+            using var context = _umbracoContextFactory.EnsureUmbracoContext();
+
+            var contentType = context.UmbracoContext.Content
+                ?.GetById(true, content.Id)
+                ?.GetType();
+
+            if (contentType == null)
+            {
+                return null;
+            }
+            var serviceType = GetRecordBuilderType(contentType);
+
+            return _serviceProvider.GetService(serviceType) as IRecordBuilder;
+        }
+
+        private Type GetRecordBuilderType(Type contentType)
+        {
+            var dictionaryKey = contentType.FullName;
+            if (_recordBuilderCache.ContainsKey(dictionaryKey))
+            {
+                return _recordBuilderCache[dictionaryKey];
+            }
+
+            var type = typeof(IRecordBuilder<>).MakeGenericType(contentType);
+            _recordBuilderCache[dictionaryKey] = type;
+            return type;
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Controllers/SearchController.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Controllers/SearchController.cs
@@ -29,8 +29,6 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Controllers
 
         private readonly IAlgoliaIndexDefinitionStorage<AlgoliaIndex> _indexStorage;
 
-        private readonly UmbracoHelper _umbracoHelper;
-
         private readonly IUserService _userService;
 
         private readonly IPublishedUrlProvider _urlProvider;
@@ -43,25 +41,25 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Controllers
 
         private readonly ILogger<SearchController> _logger;
 
+        private readonly IRecordBuilderFactory _recordBuilderFactory;
+
         public SearchController(
             IAlgoliaIndexService indexService, 
             IAlgoliaSearchService<SearchResponse<Record>> searchService, 
             IAlgoliaIndexDefinitionStorage<AlgoliaIndex> indexStorage,
-            UmbracoHelper umbracoHelper, 
             IUserService userService,
             IPublishedUrlProvider urlProvider,
             IContentService contentService,
             IAlgoliaSearchPropertyIndexValueFactory algoliaSearchPropertyIndexValueFactory,
             IUmbracoContextFactory umbracoContextFactory, 
-            ILogger<SearchController> logger)
+            ILogger<SearchController> logger, 
+            IRecordBuilderFactory recordBuilderFactory)
         {
             _indexService = indexService;
             
             _searchService = searchService;
 
             _indexStorage = indexStorage;
-
-            _umbracoHelper = umbracoHelper;
 
             _userService = userService;
 
@@ -74,6 +72,8 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Controllers
             _umbracoContextFactory = umbracoContextFactory;
             
             _logger = logger;
+
+            _recordBuilderFactory = recordBuilderFactory;
         }
 
         [HttpGet]
@@ -136,7 +136,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Controllers
 
                     foreach (var contentItem in contentItems.Where(p => !p.Trashed))
                     {
-                        var record = new ContentRecordBuilder(_userService, _urlProvider, _algoliaSearchPropertyIndexValueFactory)
+                        var record = new ContentRecordBuilder(_userService, _urlProvider, _algoliaSearchPropertyIndexValueFactory, _recordBuilderFactory)
                             .BuildFromContent(contentItem, (p) => contentDataItem.Properties.Any(q => q.Alias == p.Alias))
                             .Build();
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentCacheRefresherHandler.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentCacheRefresherHandler.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Integrations.Search.Algolia.Builders;
 using System.Text.Json;
 using Umbraco.Cms.Integrations.Search.Algolia.Models;
 using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Core.Web;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
 {
@@ -34,6 +35,8 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
 
         private readonly IAlgoliaSearchPropertyIndexValueFactory _algoliaSearchPropertyIndexValueFactory;
 
+        private readonly IRecordBuilderFactory _recordBuilderFactory;
+
         public AlgoliaContentCacheRefresherHandler(
             IServerRoleAccessor serverRoleAccessor,
             ILogger<AlgoliaContentCacheRefresherHandler> logger,
@@ -42,7 +45,8 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
             IAlgoliaIndexService indexService,
             IUserService userService,
             IPublishedUrlProvider urlProvider,
-            IAlgoliaSearchPropertyIndexValueFactory algoliaSearchPropertyIndexValueFactory)
+            IAlgoliaSearchPropertyIndexValueFactory algoliaSearchPropertyIndexValueFactory, 
+            IRecordBuilderFactory recordBuilderFactory)
         {
             _serverRoleAccessor = serverRoleAccessor;
             _contentService = contentService;
@@ -52,6 +56,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
             _userService = userService;
             _urlProvider = urlProvider;
             _algoliaSearchPropertyIndexValueFactory = algoliaSearchPropertyIndexValueFactory;
+            _recordBuilderFactory = recordBuilderFactory;
         }
 
         public async Task HandleAsync(ContentCacheRefresherNotification notification, CancellationToken cancellationToken)
@@ -98,7 +103,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
                             .FirstOrDefault(p => p.ContentType.Alias == entity.ContentType.Alias);
                         if (indexConfiguration == null || indexConfiguration.ContentType.Alias != entity.ContentType.Alias) continue;
 
-                        var record = new ContentRecordBuilder(_userService, _urlProvider, _algoliaSearchPropertyIndexValueFactory)
+                        var record = new ContentRecordBuilder(_userService, _urlProvider, _algoliaSearchPropertyIndexValueFactory, _recordBuilderFactory)
                            .BuildFromContent(entity, (p) => indexConfiguration.Properties.Any(q => q.Alias == p.Alias))
                            .Build();
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
@@ -1,12 +1,27 @@
-﻿using System.Text.Json.Serialization;
-
-namespace Umbraco.Cms.Integrations.Search.Algolia.Models
+﻿namespace Umbraco.Cms.Integrations.Search.Algolia.Models
 {
     public class Record
     {
         public Record()
         {
             Data = new Dictionary<string, object>();
+        }
+
+        public Record(Record record)
+        {
+            ContentTypeAlias = record.ContentTypeAlias;
+            ObjectID = record.ObjectID;
+            Id = record.Id;
+            Name = record.Name;
+            CreateDate = record.CreateDate;
+            CreatorName = record.CreatorName;
+            UpdateDate = record.UpdateDate;
+            WriterName = record.WriterName;
+            TemplateId = record.TemplateId;
+            Level = record.Level;
+            Path = record.Path;
+            Url = record.Url;
+            Data = record.Data;
         }
 
         public string ObjectID { get; set; }


### PR DESCRIPTION
Hi,

I believe that there is a need to add custom record values by the developers using the Algolia plugin, just as it is possible in Umbraco Examine (e.g. by subscribing to the TransformingIndexValues event).

I implemented a way to extend the default `Record` by the library users. As an example, let's assume we add a new content type called `Article` and we'd like to index an additional `customField` property. One can first extend the default `Record` class and add their custom properties, for example:

```
public class ArticleRecord : Record
{
    public ArticleRecord(Record record) : base(record)
    {
    }

    public required string CustomField { get; set; }
}
```

Then one would need to implement a generic `IRecordBuilder<>` interface where the generic type needs to extend PublishedContentModel so in this case that'd be `Article`. The method `GetRecord` needs to return the new extended Record type and set the extra properties values:

```
public class ArticleRecordBuilder : IRecordBuilder<Article>
{
    public Record GetRecord(IContent content, Record record)
    {
        return new ArticleRecord(record)
        {
            CustomField = "Custom value",
        };
    }
}
```

In the end the new record builder needs to be registered in services, for example:

```
services.AddScoped<IRecordBuilder<Article>, ArticleRecordBuilder>();
```

As a result after rebuilding an index, the Algolia index contains the extra field value:

![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/40027605/209aa73f-946d-4a8d-ba3c-926d3e24d516)

Let me know what you think of such solution and if it can be added to the plugin in this or different form, thanks!