### PR TITLE
Add Shopify pagination

### DIFF
--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/Render/Products.cshtml
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/Render/Products.cshtml
@@ -7,7 +7,10 @@
         {
             <dt class="product-title">@product.Title</dt>
             <dd class="product-body">@Html.Raw(product.Body)</dd>
-            <img class="product-image" src="@product.Image" alt="@product.Title" />
+            @if (!string.IsNullOrEmpty(product.Image))
+            {
+                <img class="product-image" src="@product.Image" alt="@product.Title" />
+            }
         }
     </dl>
 }

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/Render/ProductsV9.cshtml
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/Render/ProductsV9.cshtml
@@ -7,10 +7,10 @@
         {
             <dt class="product-title">@product.Title</dt>
             <dd class="product-body">@Html.Raw(product.Body)</dd>
-            <img class="product-image" src="@product.Image" alt="@product.Title" />
+            @if (!string.IsNullOrEmpty(product.Image))
+            {
+                <img class="product-image" src="@product.Image" alt="@product.Title" />
+            }
         }
     </dl>
 }
-
-
-

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/css/shopify.css
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/css/shopify.css
@@ -1,0 +1,1 @@
+﻿.shopify-pagination .umb-pagination.pagination li:not(:first-child):not(:last-child) { display: none; }

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/js/shopify.resource.js
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/js/shopify.resource.js
@@ -29,9 +29,17 @@
                         $http.get(`${apiEndpoint}/ValidateAccessToken`),
                         "Failed");
                 },
-                getProductsList: function() {
+                getProductsList: function(pageInfo) {
                     return umbRequestHelper.resourcePromise(
-                        $http.get(`${apiEndpoint}/GetList`), "Failed to get resource");
+                        $http.get(`${apiEndpoint}/GetList?pageInfo=${pageInfo}`), "Failed to get resource");
+                },
+                getProductsByIds: function (ids) {
+                    return umbRequestHelper.resourcePromise(
+                        $http.post(`${apiEndpoint}/GetListByIds`, { ids: ids }), "Failed to get resource");
+                },
+                getTotalPages: function () {
+                    return umbRequestHelper.resourcePromise(
+                        $http.get(`${apiEndpoint}/GetTotalPages`), "Failed to get resource");
                 }
             };
         });

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/package.manifest
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/package.manifest
@@ -7,5 +7,8 @@
     "~/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/js/productPickerSettings.controller.js",
     "~/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/js/shopify.resource.js",
     "~/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/js/shopify.service.js"
+  ],
+  "css": [
+    "~/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/css/shopify.css"
   ]
 }

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/views/productPickerOverlay.html
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/views/productPickerOverlay.html
@@ -77,7 +77,7 @@
                         <localize key="content_listViewNoItems">There are no products in the list.</localize>
                     </umb-empty-state>
                     <!-- Pagination -->
-                    <div class="flex justify-center" ng-show="!vm.loading">
+                    <div class="shopify-pagination flex justify-center" ng-show="!vm.loading">
                         <umb-pagination page-number="vm.pagination.pageNumber"
                                         total-pages="vm.pagination.totalPages"
                                         on-next="vm.nextPage"

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/views/productPickerOverlay.html
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/App_Plugins/UmbracoCms.Integrations/Commerce/Shopify/views/productPickerOverlay.html
@@ -76,6 +76,16 @@
                                      position="center">
                         <localize key="content_listViewNoItems">There are no products in the list.</localize>
                     </umb-empty-state>
+                    <!-- Pagination -->
+                    <div class="flex justify-center" ng-show="!vm.loading">
+                        <umb-pagination page-number="vm.pagination.pageNumber"
+                                        total-pages="vm.pagination.totalPages"
+                                        on-next="vm.nextPage"
+                                        on-prev="vm.prevPage"
+                                        on-change="vm.changePage"
+                                        on-go-to-page="vm.goToPage">
+                        </umb-pagination>
+                    </div>
 
                     <!-- Min Max help messages-->
                     <div class="umb-contentpicker__min-max-help" ng-if="(model.config.validationLimit.max > 1 || model.config.validationLimit.min > 0)">

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Constants.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Constants.cs
@@ -9,6 +9,10 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify
 
         public const string ProductsApiEndpoint = "https://{0}.myshopify.com/admin/api/{1}/products.json";
 
+        public const string ProductsCountApiEndpoint = "https://{0}.myshopify.com/admin/api/{1}/products/count.json";
+
+        public const int DEFAULT_PAGE_SIZE = 10;
+
         public static class RenderingComponent
         {
             public const string DefaultV8ViewPath = AppPluginFolderPath + "/Render/Products.cshtml";

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Controllers/ProductsController.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Controllers/ProductsController.cs
@@ -6,6 +6,8 @@ using Umbraco.Cms.Integrations.Commerce.Shopify.Services;
 using Umbraco.Cms.Integrations.Commerce.Shopify.Configuration;
 
 using static Umbraco.Cms.Integrations.Commerce.Shopify.ShopifyComposer;
+using System.Linq;
+
 
 #if NETCOREAPP
 using Microsoft.Extensions.Options;
@@ -63,6 +65,17 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Controllers
         [HttpPost]
         public void RevokeAccessToken() => _apiService.RevokeAccessToken();
 
-        public async Task<ResponseDto<ProductsListDto>> GetList() => await _apiService.GetResults();
+        public async Task<ResponseDto<ProductsListDto>> GetList(string pageInfo) => await _apiService.GetResults(pageInfo);
+
+        public async Task<ResponseDto<ProductsListDto>> GetListByIds([FromBody] RequestDto dto) => 
+            await _apiService.GetProductsByIds(dto.Ids.Select(p => (long.Parse(p))).ToArray());
+
+        [HttpGet]
+        public async Task<int> GetTotalPages()
+        {
+            var productsCount = await _apiService.GetCount();
+
+            return productsCount / Constants.DEFAULT_PAGE_SIZE + 1;
+        }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
@@ -48,21 +48,20 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Editors
         {
             if (inter == null) return null;
 
-            var ids = (long[]) inter;
+            var ids = (long[])inter;
 
-            var t = Task.Run(async () => await _apiService.GetResults());
+            var t = Task.Run(async () => await _apiService.GetProductsByIds(ids));
 
             var result = t.Result;
 
             var products = from p in result.Result.Products
-                where ids.Contains(p.Id)
-                select new ProductViewModel
-                {
-                    Id = p.Id,
-                    Title = p.Title,
-                    Body = p.Body,
-                    Image = p.Image.Src
-                };
+                           select new ProductViewModel
+                           {
+                               Id = p.Id,
+                               Title = p.Title,
+                               Body = p.Body,
+                               Image = p.Image?.Src
+                           };
 
             return products.ToList();
         }

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Helpers/HttpResponseHelper.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Helpers/HttpResponseHelper.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Web;
+
+namespace Umbraco.Cms.Integrations.Commerce.Shopify.Helpers
+{
+    public static class HttpResponseHelper
+    {
+        /// <summary>
+        /// Retrieve Shopify page_info query string parameters used for pagination from forward/backwards operations.
+        /// </summary>
+        /// <param name="response"></param>
+        /// <returns></returns>
+        public static Tuple<string, string> GetPageInfo(this HttpResponseMessage response)
+        {
+            string previousPageInfo = string.Empty;
+            string nextPageInfo = string.Empty;
+
+            if (!response.Headers.Contains("Link"))
+            {
+                return default;
+            }
+
+            var linkHeader = response.Headers.GetValues("Link").FirstOrDefault();
+            if (linkHeader != null && linkHeader.Contains("rel"))
+            {
+                if (linkHeader.Contains("previous") && linkHeader.Contains("next"))
+                {
+                    var relArr = linkHeader.Split(',');
+                    foreach (var item in relArr)
+                    {
+                        var link = item.Split(';');
+                        var servicePageInfo = HttpUtility.ParseQueryString(link[0].Replace("<", string.Empty).Replace(">", string.Empty)).Get("page_info");
+                        if (link[1].Contains("previous"))
+                        {
+                            previousPageInfo = servicePageInfo;
+                        }
+                        else if (link[1].Contains("next"))
+                        {
+                            nextPageInfo = servicePageInfo;
+                        }
+                    }
+                }
+                else
+                {
+                    var link = linkHeader.Split(';');
+                    var servicePageInfo = HttpUtility.ParseQueryString(link[0].Replace("<", string.Empty).Replace(">", string.Empty)).Get("page_info");
+                    if (link[1].Contains("previous"))
+                    {
+                        previousPageInfo = servicePageInfo;
+                    }
+                    else if (link[1].Contains("next"))
+                    {
+                        nextPageInfo = servicePageInfo;
+                    }
+                }
+
+            }
+
+            return new Tuple<string, string>(previousPageInfo, nextPageInfo);
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/Dtos/RequestDto.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/Dtos/RequestDto.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Umbraco.Cms.Integrations.Commerce.Shopify.Models.Dtos
+{
+    public class RequestDto
+    {
+        [JsonProperty("ids")]
+        public string[] Ids { get; set; }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/Dtos/ResponseDto.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/Dtos/ResponseDto.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Umbraco.Cms.Integrations.Commerce.Shopify.Models.Dtos
 {
@@ -9,6 +7,12 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Models.Dtos
     {
         [JsonProperty("isValid")]
         public bool IsValid { get; set; }
+
+        [JsonProperty("nextPageInfo")]
+        public string NextPageInfo { get; set; }
+
+        [JsonProperty("previousPageInfo")]
+        public string PreviousPageInfo { get; set; }
 
         [JsonProperty("isExpired")]
         public bool IsExpired { get; set; }

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Services/IShopifyService.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Services/IShopifyService.cs
@@ -13,6 +13,10 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Services
 
         void RevokeAccessToken();
 
-        Task<ResponseDto<ProductsListDto>> GetResults();
+        Task<ResponseDto<ProductsListDto>> GetResults(string pageInfo);
+
+        Task<ResponseDto<ProductsListDto>> GetProductsByIds(long[] ids);
+
+        Task<int> GetCount();
     }
 }

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Umbraco.Cms.Integrations.Commerce.Shopify.csproj
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Umbraco.Cms.Integrations.Commerce.Shopify.csproj
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Commerce.Shopify</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>1.1.4</Version>
+		<Version>1.2.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR contains the implementation of pagination feature for integration with _Shopify_.

The feature is slightly different from a normal pagination feature, due to _Shopify's_ [`relative cursor-based pagination`](https://www.shopify.com/partners/blog/relative-pagination). With version `2019-07` of their API, _Shopify_ no longer accepts a `page` parameter with their requests and have moved to relative pagination.

With relative pagination, I am using the `Link` header from the response to pick the necessary information for moving forward or backwards through the records. Every request that has multiple pages, will include a response header called `Link`. this header contains the URLs for the previous and next pages, if they exist, respecting the sort order asked for. 

The data needed to load the next page is embedded into a query string parameter called `page_info`. The number of records per page is defaulted to 10, using a constant value, and are passed to each request using the `limit` parameter.

Some patterns for the `Link` header response:
- Load first page
Response will contain a `Link` header with details of the next page, in this format:
```
<https://my-umbraco.myshopify.com/admin/api/2024-01/products.json?limit=10&page_info=[*****]>; rel="next"
```
- Load last page
Response will contain a `Link` header with details of the next page, in this format:
```
<https://my-umbraco.myshopify.com/admin/api/2024-01/products.json?limit=10&page_info=[*****]>; rel="previous"
```
- Load a middle page
Response will contain a `Link` header with details of the next page, in this format:
```
<https://my-umbraco.myshopify.com/admin/api/2024-01/products.json?limit=3&page_info=[*****]>; rel="previous", 
<https://my-umbraco.myshopify.com/admin/api/2024-01/products.json?limit=3&page_info=[*****]>; rel="next"
```

Instead of using the actual URLs from the header, I am just picking the `page_info` parameter with specifications of next/previous, and using it in the controller/service.

Other updates included:
- Return products count using a separate HTTP request to `https://my-umbraco.myshopify.com/admin/api/2024-01/products/count.json`. After the configuration is validated, the `vm.pagination.totalPages` property is set with the count.
- When retrieving products for a page, the response object contains two properties (`nextPageInfo` and `previousPageInfo`) with the `page_info` parameter used to toggle pages.
- `umb-pagination` directive used has a different behavior - because I am unable to sent an actual page to the API, we can only move one step ahead or back. This means that if a specific page is selected, I cannot jump to the exact page, I just force the pagination to jump with just one position, simulating the same behavior when pressing `Next`/`Previous`.
- Value converter updated to support new implementation
- `HttpResponseHelper` helper method to parse the adequate `page_info` parameters.

We can have a demo tomorrow in our 1-1, only issue I've encountered is with displaying the selected products in the grid when the overlay is opened (e.g., if I select products from page 3, save them and try to select new products, the list view will show me the first page. Only if I move to the 3rd page again, I will be able to see my selected products).



