### PR TITLE
Use correct wording at HubSpot

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository houses open-source extensions, created for Umbraco CMS, that int
 
 ### CRM
 
-[HubSpot](./src/Umbraco.Cms.Integrations.Crm.Hubspot/) - a form picker and rendering component for Hubspot forms.
+[HubSpot](./src/Umbraco.Cms.Integrations.Crm.Hubspot/) - a form picker and rendering component for HubSpot forms.
 
 [Dynamics](./src/Umbraco.Cms.Integrations.Crm.Dynamics/) - a form picker and rendering component for Dynamics 365 Marketing forms.
 

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Constants.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Constants.cs
@@ -25,9 +25,9 @@
 
             public const string InvalidApiKey = "Invalid API key.";
 
-            public const string ApiKeyMissing = "Cannot access Hubspot - API key is missing";
+            public const string ApiKeyMissing = "Cannot access HubSpot - API key is missing";
 
-            public const string AccessTokenMissing = "Cannot access Hubspot - Access Token is missing.";
+            public const string AccessTokenMissing = "Cannot access HubSpot - Access Token is missing.";
 
             public const string OAuthInvalidToken = "Unable to connect to HubSpot. Please review the settings of the form picker property's data type.";
 

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Resources/LoggingResources.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Resources/LoggingResources.cs
@@ -4,8 +4,8 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Core.Resources
     public static class LoggingResources
     {
         public const string ApiFetchFormsFailed =
-            "Failed to fetch forms from Hubspot using API key: {0}";
+            "Failed to fetch forms from HubSpot using API key: {0}";
 
-        public const string OAuthFetchFormsFailed = "Failed to fetch forms from Hubspot using OAuth: {0}";
+        public const string OAuthFetchFormsFailed = "Failed to fetch forms from HubSpot using OAuth: {0}";
     }
 }

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Umbraco.Cms.Integrations.Crm.Hubspot.Core.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Umbraco.Cms.Integrations.Crm.Hubspot.Core.csproj
@@ -7,7 +7,7 @@
 	<PropertyGroup>
 		<PackageId>Umbraco.Cms.Integrations.Crm.Hubspot.Core</PackageId>
 		<Title>Umbraco CMS Integrations: CRM - Hubspot.Core</Title>
-		<Description>Core package for Umbraco CMS integration with Hubspot.</Description>
+		<Description>Core package for Umbraco CMS integration with HubSpot.</Description>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Crm.Hubspot</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>


### PR DESCRIPTION
The wording of Hubspot should be `HubSpot`.

The classes, properties etc. could eventually be updated, but isn't crucial.

See also: https://github.com/umbraco/Umbraco.Forms.Integrations/pull/97