### PR TITLE
Fix Variant VariesByCulture issue

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
@@ -76,7 +76,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
                     }
                     else
                     {
-                        var indexValue = _algoliaSearchPropertyIndexValueFactory.GetValue(property, string.Empty);
+                        var indexValue = _algoliaSearchPropertyIndexValueFactory.GetValue(property, null);
                         _record.Data.Add(indexValue.Key, indexValue.Value);
                     }
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
@@ -28,7 +28,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
                 return default;
             }
 
-            var indexValues = propertyEditor.PropertyIndexValueFactory.GetIndexValues(property, culture, string.Empty, true);
+            var indexValues = propertyEditor.PropertyIndexValueFactory.GetIndexValues(property, culture, null, true);
 
             if (indexValues == null || !indexValues.Any()) return new KeyValuePair<string, object>(property.Alias, string.Empty);
 


### PR DESCRIPTION
**Description**
I found an issue, while using the Umbraco Algolia integration, when trying to index content which has nested content.

**How to replicate**
Install a fresh version of Umbraco 13 with the clean starter kit, and add the Umbraco.Cms.Integrations.Search.Algolia package.
To into Umbraco Backoffice and navigate to Algolia Search Management.
Add a new Index Definition, and pick Article.
If you only pick Title and Subtitle, and to back to Build the index, it will work, but if you include Content Rows, you will get this error.
![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/6458892/db4c96b7-524c-4ef2-9e03-aaaca221314a)

**What is fixed in this PR?**
The problem lies in the fact culture and segment is set to be string.Empty, when trying to get the IndexValue for the property, but when validating the property, it only checks if the culture or segment values are null, and not if they are empty strings.

I have changed the two string.Empty values to null, so they get validated correctly later in the code.
More specifically in 
`Umbraco.Cms.Core.PropertyEditors.NestedPropertyIndexValueFactoryBase`
in this part of the Handle method

```
// We want to ensure that the nested properties are set vary by culture if the parent is
// This is because it's perfectly valid to have a nested property type that's set to invariant even if the parent varies.
// For instance in a block list, the list it self can vary, but the elements can be invariant, at the same time.
if (culture is not null)
{
    propertyType.Variations |= ContentVariation.Culture;
}

if (segment is not null)
{
    propertyType.Variations |= ContentVariation.Segment;
}

return propertyType;
```

