### PR TITLE
Bugfix/semrush auth UI status

### DIFF
--- a/src/Umbraco.Cms.Integrations.SEO.Semrush/App_Plugins/UmbracoCms.Integrations/SEO/Semrush/semrush.controller.js
+++ b/src/Umbraco.Cms.Integrations.SEO.Semrush/App_Plugins/UmbracoCms.Integrations/SEO/Semrush/semrush.controller.js
@@ -200,7 +200,7 @@
         function validateToken() {
             umbracoCmsIntegrationsSemrushResource.validateToken().then(function (response) {
                 vm.isFreeAccount = response.isFreeAccount;
-                if (response.isExpired) {
+                if (!response.isAuthorized) {
                     vm.isConnected = false;
                 } else {
                     if (response.isValid === false) {
@@ -275,6 +275,7 @@
             var options = {
                 title: "SEMrush Authorization Details",
                 isFreeAccount: vm.isFreeAccount,
+                isAuthorized: vm.isConnected,
                 view: "/App_Plugins/UmbracoCms.Integrations/SEO/Semrush/statusEditor.html",
                 size: "small",
                 revoke: function () {

--- a/src/Umbraco.Cms.Integrations.SEO.Semrush/App_Plugins/UmbracoCms.Integrations/SEO/Semrush/status.controller.js
+++ b/src/Umbraco.Cms.Integrations.SEO.Semrush/App_Plugins/UmbracoCms.Integrations/SEO/Semrush/status.controller.js
@@ -4,7 +4,8 @@
 
         var vm = this;
 
-        vm.isFreeAccount = $scope.model.isFreeAccount !== null
+        vm.isAuthorized = $scope.model.isAuthorized;
+        vm.isFreeAccount = $scope.model.isFreeAccount !== null && $scope.model.isAuthorized
             ? ($scope.model.isFreeAccount === true ? "Free" : "Paid") : "N.A.";
 
         umbracoCmsIntegrationsSemrushResource.getTokenDetails().then(function (response) {

--- a/src/Umbraco.Cms.Integrations.SEO.Semrush/App_Plugins/UmbracoCms.Integrations/SEO/Semrush/statusEditor.html
+++ b/src/Umbraco.Cms.Integrations.SEO.Semrush/App_Plugins/UmbracoCms.Integrations/SEO/Semrush/statusEditor.html
@@ -4,7 +4,7 @@
         <umb-editor-container>
             <umb-box>
                 <umb-box-content>
-                    <p><b>Connected:</b> {{ vm.isAccessTokenAvailable }}</p>
+                    <p><b>Connected:</b> {{ vm.isAccessTokenAvailable && vm.isAuthorized }}</p>
                     <p><b>Account:</b> {{ vm.isFreeAccount }}</p>
                     <p ng-if="vm.isAccessTokenAvailable"><b>Access Token:</b> {{ vm.AccessToken }}</p>
                     <umb-button action="vm.onRevokeToken()"

--- a/src/Umbraco.Cms.Integrations.SEO.Semrush/Constants.cs
+++ b/src/Umbraco.Cms.Integrations.SEO.Semrush/Constants.cs
@@ -11,6 +11,8 @@ namespace Umbraco.Cms.Integrations.SEO.Semrush
 
         public const string SemrushKeywordsEndpoint = "{0}api/v1/keywords/{1}?access_token={2}&phrase={3}&database={4}";
 
+        public const string BadRefreshToken = "BAD_REFRESH_TOKEN";
+
         public static class Configuration
         {
             public const string Settings = "Umbraco:Cms:Integrations:SEO:Semrush:Settings";

--- a/src/Umbraco.Cms.Integrations.SEO.Semrush/Models/Dtos/AuthorizationResponseDto.cs
+++ b/src/Umbraco.Cms.Integrations.SEO.Semrush/Models/Dtos/AuthorizationResponseDto.cs
@@ -5,8 +5,8 @@ namespace Umbraco.Cms.Integrations.SEO.Semrush.Models.Dtos
 {
     public class AuthorizationResponseDto
     {
-        [JsonProperty("isExpired")]
-        public bool IsExpired { get; set; }
+        [JsonProperty("isAuthorized")]
+        public bool IsAuthorized { get; set; }
 
         [JsonProperty("isValid")]
         public bool IsValid { get; set; }

--- a/src/Umbraco.Cms.Integrations.SEO.Semrush/Services/AuthorizationService.cs
+++ b/src/Umbraco.Cms.Integrations.SEO.Semrush/Services/AuthorizationService.cs
@@ -6,6 +6,10 @@ using System.Threading.Tasks;
 using Umbraco.Cms.Integrations.SEO.Semrush.Configuration;
 using System.Net.Http;
 using Umbraco.Cms.Integrations.SEO.Semrush.Models.Dtos;
+using Newtonsoft.Json.Linq;
+
+using Newtonsoft.Json;
+
 
 #if NETCOREAPP
 using Microsoft.Extensions.Options;
@@ -96,6 +100,16 @@ namespace Umbraco.Cms.Integrations.SEO.Semrush.Services
                 SemrushTokenService.SaveParameters(Constants.TokenDbKey, result);
 
                 return result;
+            }
+            else
+            {
+                var responseContent = await response.Content.ReadAsStringAsync();
+
+                var statusObject = (JObject)JsonConvert.DeserializeObject(responseContent);
+                if (statusObject.ContainsKey("status") && statusObject["status"].ToString() == Constants.BadRefreshToken)
+                {
+                    SemrushTokenService.RemoveParameters(Constants.TokenDbKey);
+                }
             }
 
             return "error";

--- a/src/Umbraco.Cms.Integrations.SEO.Semrush/Umbraco.Cms.Integrations.SEO.Semrush.csproj
+++ b/src/Umbraco.Cms.Integrations.SEO.Semrush/Umbraco.Cms.Integrations.SEO.Semrush.csproj
@@ -62,10 +62,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Compile Remove="SemrushComponent.cs" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<Content Include="semrush.png">
 			<Pack>true</Pack>
 			<PackagePath>\</PackagePath>


### PR DESCRIPTION
Current PR adds some updates to the UI of the context app as a result of issue #177. 

In a context where the access token is tampered with, or it has expired without possibility of using the refresh token to exchange a new one, the UI misleads the editor into thinking that the status is `Connected` and allow him to make requests, without getting a visual status of the action.

To fix this, I've introduced the `IsAuthorized` flag, which is set in the first call to the _Semrush_ service to `ValidateToken`. During this call, in case of an `Unauthorized` status code, the refresh token action of the authorization token service is called.

The response from _Semrush_ in case of an invalid refresh token action has this format, so I am using this to remove the value from the database.
```
{"status":"BAD_REFRESH_TOKEN","message":"missing or invalid refresh token","correlationId":"58673150-43e1-473d-9a9a-cc6dd8d7149a"}
```