### PR TITLE
Feature: Change Record.Path to be a list of strings

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
 
             _record.TemplateId = content.TemplateId.HasValue ? content.TemplateId.Value : -1;
             _record.Level = content.Level;
-            _record.Path = content.Path;
+            _record.Path = content.Path.Split(",").ToList();
             _record.ContentTypeAlias = content.ContentType.Alias;
             _record.Url = _urlProvider.GetUrl(content.Id);
             _record.Data = new();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
 
             _record.TemplateId = content.TemplateId.HasValue ? content.TemplateId.Value : -1;
             _record.Level = content.Level;
-            _record.Path = content.Path.Split(",").ToList();
+            _record.Path = content.Path.Split(',').ToList();
             _record.ContentTypeAlias = content.ContentType.Alias;
             _record.Url = _urlProvider.GetUrl(content.Id);
             _record.Data = new();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
@@ -42,7 +42,7 @@
 
         public int Level { get; set; }
 
-        public string Path { get; set; }
+        public List<string> Path { get; set; }
 
         public string ContentTypeAlias { get; set; }
 


### PR DESCRIPTION
**Description**
Right now the Path property on Record is a string.
The Path property in the Record class is retrieved from the Path property in the IContent class.
The Path is a comma separated list of ids, and looks something like this "-1,2289,2290,2748".

As it is now. You can't do any filtering by path, because you can't do custom searches like that in Algolia.
By changing the Path property to a List of strings, you can do better searches, by filtering using path.

Examples for this could be
- Hiding content until a user is logged in
- Give the user a dropdown to filter by different path roots
- Hiding content branches entirely using the root path