### PR TITLE
Add ActiveCampaign Form Picker pagination

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/ActiveCampaignComposer.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/ActiveCampaignComposer.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-using System;
-
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Configuration;
@@ -19,7 +17,7 @@ namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core
                 .AddHttpClient(Constants.FormsHttpClient, client =>
                     {
                         client.BaseAddress = new Uri(
-                            $"{builder.Config.GetSection(Constants.SettingsPath)[nameof(ActiveCampaignSettings.BaseUrl)]}/api/3/forms");
+                            $"{builder.Config.GetSection(Constants.SettingsPath)[nameof(ActiveCampaignSettings.BaseUrl)]}");
                         client.DefaultRequestHeaders
                             .Add("Api-Token", builder.Config.GetSection(Constants.SettingsPath)[nameof(ActiveCampaignSettings.ApiKey)]);
                     });

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Constants.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Constants.cs
@@ -9,6 +9,8 @@ namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core
 
         public const string FormsHttpClient = "FormsClient";
 
+        public const int DEFAULT_PAGE_SIZE = 10;
+
         public class Resources
         {
             public const string AuthorizationFailed = "ActiveCampaign authorization failed.";

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/FormCollectionResponseDto.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/FormCollectionResponseDto.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Models.Dtos
 {
@@ -7,5 +6,8 @@ namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Models.Dtos
     {
         [JsonPropertyName("forms")]
         public List<FormDto> Form { get; set; }
+
+        [JsonPropertyName("meta")]
+        public MetaDto Meta { get; set; }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/MetaDto.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core/Models/Dtos/MetaDto.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign.Core.Models.Dtos
+{
+    public class MetaDto
+    {
+        [JsonPropertyName("total")]
+        public string Total { get; set; }
+
+        [JsonPropertyName("totalPages")]
+        public int TotalPages => int.TryParse(Total, out var total) ? total / Constants.DEFAULT_PAGE_SIZE : 0;
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/js/activecampaign.resource.js
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/js/activecampaign.resource.js
@@ -9,9 +9,9 @@
                     $http.get(`${apiEndpoint}/CheckApiAccess`),
                     "Failed");
             },
-            getForms: function () {
+            getForms: function (page) {
                 return umbRequestHelper.resourcePromise(
-                    $http.get(`${apiEndpoint}/GetForms`),
+                    $http.get(`${apiEndpoint}/GetForms?page=${page}`),
                     "Failed");
             },
             getForm: function (id) {

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/js/formpicker.controller.js
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/js/formpicker.controller.js
@@ -9,6 +9,16 @@
 
     vm.status = "";
 
+    // pagination
+    vm.pagination = {
+        pageNumber: 1,
+        totalPages: 1
+    };
+    vm.nextPage = goToPage;
+    vm.prevPage = goToPage;
+    vm.changePage = goToPage;
+    vm.goToPage = goToPage;
+
     umbracoCmsIntegrationsCrmActiveCampaignResource.checkApiAccess().then(function (response) {
         vm.isApiConfigurationValid = response.isApiConfigurationValid;
         if (response.isApiConfigurationValid) {
@@ -69,12 +79,16 @@
         });
     }
 
-    function loadForms() {
+    function loadForms(page) {
         vm.loading = true;
-        umbracoCmsIntegrationsCrmActiveCampaignResource.getForms().then(function (response) {
+        umbracoCmsIntegrationsCrmActiveCampaignResource.getForms(page).then(function (response) {
+
             vm.formsList = [];
 
             if (response.forms != null) {
+
+                vm.pagination.totalPages = response.meta.totalPages;
+
                 response.forms.forEach(item => {
                     vm.formsList.push({
                         id: item.id,
@@ -86,6 +100,11 @@
 
             vm.loading = false;
         });
+    }
+
+    // pagination events
+    function goToPage(page) {
+        loadForms(page);
     }
 }
 

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/views/formpickereditor.html
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/App_Plugins/UmbracoCms.Integrations/Crm/ActiveCampaign/views/formpickereditor.html
@@ -24,6 +24,21 @@
                                 </a>
                             </li>
                         </ul>
+                        <!-- If list is empty, then display -->
+                        <umb-empty-state ng-if="!vm.formsList"
+                                         position="center">
+                            <localize key="content_listViewNoItems">There are no forms in the list.</localize>
+                        </umb-empty-state>
+                        <!-- Pagination -->
+                        <div class="flex justify-center" ng-show="!vm.loading">
+                            <umb-pagination page-number="vm.pagination.pageNumber"
+                                            total-pages="vm.pagination.totalPages"
+                                            on-next="vm.nextPage"
+                                            on-prev="vm.prevPage"
+                                            on-change="vm.changePage"
+                                            on-go-to-page="vm.goToPage">
+                            </umb-pagination>
+                        </div>
                     </div>
 
                     <div ng-if="vm.status" class="alert alert-warning">


### PR DESCRIPTION
Current PR adds pagination to the _ActiveCampaign_ Form Picker, following issue #180 .

By default, the number of results is limited to 20 (with a max of 100), therefor I have introduced a default size of 10 for the number of items displayed on a page, value that I then use as a query string parameter - `limit` - to toggle the number of results. Navigating the forms is managed through an additional query string parameter called `offset`, a zero-based index.

For example, the initial request will be `/api/3/forms?limit=10`, to get the first 10 items, then for other pages the path will be `/api/3/forms?limit=10&offset=[(page - 1)*pageSize]`.

More details on pagination can be found [here](https://developers.activecampaign.com/reference/pagination).

The update can be viewed in action in this [demo](https://us02web.zoom.us/clips/share/AQC5u5TWS0JfPcqRuKNPVZnQVKrolctGOrxDY7j-3i-ZmTUn9_fxJRXAUIXm7B-XMjZz0OVk29DnO73NztfwIiyPBA.e4OVZmwbmDdr0kHh).

