### PR TITLE
fix error in GetRecordBuilderType MakeGenericTyoe in Algolia

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/IRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/IRecordBuilder.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
     }
 
     public interface IRecordBuilder<in TContentType> 
-        : IRecordBuilder where TContentType : PublishedContentModel 
+        : IRecordBuilder where TContentType : IPublishedContent 
     {
     }
 }


### PR DESCRIPTION
Using Umbraco 13.2.2 and Algolia 2.1.2 there is a serious bug with building indexes.

MakeGenericType in Recordsbuilder will throw an error using PublishedContentModel.
Changed it to IPublishedContent and the issue goes away and the builder works.

![image](https://github.com/umbraco/Umbraco.Cms.Integrations/assets/5107226/c76f8655-7145-46bf-9969-c1d08c91b6ad)
