### PR TITLE
fix path property from list<string> to string after change on IRecordbuilder

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
 
             _record.TemplateId = content.TemplateId.HasValue ? content.TemplateId.Value : -1;
             _record.Level = content.Level;
-            _record.Path = content.Path.Split(',').ToList();
+            _record.Path = content.Path;
             _record.ContentTypeAlias = content.ContentType.Alias;
             _record.Url = _urlProvider.GetUrl(content.Id);
             _record.Data = new();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentCacheRefresherHandler.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentCacheRefresherHandler.cs
@@ -1,19 +1,17 @@
 ﻿using Microsoft.Extensions.Logging;
-
+using System.Text.Json;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
-using Umbraco.Cms.Core.Notifications;
-using Umbraco.Cms.Core.Services.Changes;
-using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Routing;
-using Umbraco.Cms.Integrations.Search.Algolia.Migrations;
-using Umbraco.Cms.Integrations.Search.Algolia.Services;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Integrations.Search.Algolia.Builders;
-using System.Text.Json;
-using Umbraco.Cms.Integrations.Search.Algolia.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Changes;
 using Umbraco.Cms.Core.Sync;
-using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Integrations.Search.Algolia.Builders;
+using Umbraco.Cms.Integrations.Search.Algolia.Migrations;
+using Umbraco.Cms.Integrations.Search.Algolia.Models;
+using Umbraco.Cms.Integrations.Search.Algolia.Services;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
 {

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
@@ -19,7 +19,7 @@
             WriterName = record.WriterName;
             TemplateId = record.TemplateId;
             Level = record.Level;
-            Path = record.Path;
+            Path = string.Join(",",record.Path);
             Url = record.Url;
             Data = record.Data;
         }
@@ -42,7 +42,7 @@
 
         public int Level { get; set; }
 
-        public List<string> Path { get; set; }
+        public string Path { get; set; }
 
         public string ContentTypeAlias { get; set; }
 


### PR DESCRIPTION
After changing the IRecordbuilder to inherit from IPublishedContent the index could not be serialized.

There was a difference in how Path property is set up. Changing it from List<string to string fixed the issues.

Tested full rebuild of the index and also publish a single node.