### PR TITLE
Bug/add context

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Integrations.Search.Algolia.Models;
 using Umbraco.Cms.Integrations.Search.Algolia.Services;
 using Umbraco.Extensions;
@@ -19,7 +20,9 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
 
         private readonly IRecordBuilderFactory _recordBuilderFactory;
 
-        public ContentRecordBuilder(IUserService userService, IPublishedUrlProvider urlProvider, IAlgoliaSearchPropertyIndexValueFactory algoliaSearchPropertyIndexValueFactory, IRecordBuilderFactory recordBuilderFactory)
+        private readonly IUmbracoContextFactory _umbracoContextFactory;
+
+        public ContentRecordBuilder(IUserService userService, IPublishedUrlProvider urlProvider, IAlgoliaSearchPropertyIndexValueFactory algoliaSearchPropertyIndexValueFactory, IRecordBuilderFactory recordBuilderFactory, IUmbracoContextFactory umbracoContextFactory)
         {
             _userService = userService;
 
@@ -28,10 +31,14 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
             _algoliaSearchPropertyIndexValueFactory = algoliaSearchPropertyIndexValueFactory;
 
             _recordBuilderFactory = recordBuilderFactory;
+
+            _umbracoContextFactory = umbracoContextFactory;
         }
 
         public ContentRecordBuilder BuildFromContent(IContent content, Func<IProperty, bool> filter = null)
         {
+            using var contextReference = _umbracoContextFactory.EnsureUmbracoContext();
+
             _record.ObjectID = content.Key.ToString();
 
             var creator = _userService.GetProfileById(content.CreatorId);
@@ -47,7 +54,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
 
             _record.TemplateId = content.TemplateId.HasValue ? content.TemplateId.Value : -1;
             _record.Level = content.Level;
-            _record.Path = content.Path;
+            _record.Path = content.Path.Split(',').ToList();
             _record.ContentTypeAlias = content.ContentType.Alias;
             _record.Url = _urlProvider.GetUrl(content.Id);
             _record.Data = new();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
@@ -47,7 +47,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
 
             _record.TemplateId = content.TemplateId.HasValue ? content.TemplateId.Value : -1;
             _record.Level = content.Level;
-            _record.Path = content.Path.Split(',').ToList();
+            _record.Path = content.Path;
             _record.ContentTypeAlias = content.ContentType.Alias;
             _record.Url = _urlProvider.GetUrl(content.Id);
             _record.Data = new();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Controllers/SearchController.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Controllers/SearchController.cs
@@ -1,20 +1,15 @@
-﻿using System.Diagnostics;
-using Algolia.Search.Models.Search;
-
+﻿using Algolia.Search.Models.Search;
 using Microsoft.AspNetCore.Mvc;
-
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using System.Text.Json;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Services.Implement;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Integrations.Search.Algolia.Builders;
 using Umbraco.Cms.Integrations.Search.Algolia.Migrations;
 using Umbraco.Cms.Integrations.Search.Algolia.Models;
 using Umbraco.Cms.Integrations.Search.Algolia.Services;
 using Umbraco.Cms.Web.BackOffice.Controllers;
-using Umbraco.Cms.Web.Common;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Extensions;
 
@@ -136,7 +131,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Controllers
 
                     foreach (var contentItem in contentItems.Where(p => !p.Trashed))
                     {
-                        var record = new ContentRecordBuilder(_userService, _urlProvider, _algoliaSearchPropertyIndexValueFactory, _recordBuilderFactory)
+                        var record = new ContentRecordBuilder(_userService, _urlProvider, _algoliaSearchPropertyIndexValueFactory, _recordBuilderFactory, _umbracoContextFactory)
                             .BuildFromContent(contentItem, (p) => contentDataItem.Properties.Any(q => q.Alias == p.Alias))
                             .Build();
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentCacheRefresherHandler.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentCacheRefresherHandler.cs
@@ -1,19 +1,17 @@
 ﻿using Microsoft.Extensions.Logging;
-
+using System.Text.Json;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
-using Umbraco.Cms.Core.Notifications;
-using Umbraco.Cms.Core.Services.Changes;
-using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Routing;
-using Umbraco.Cms.Integrations.Search.Algolia.Migrations;
-using Umbraco.Cms.Integrations.Search.Algolia.Services;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Integrations.Search.Algolia.Builders;
-using System.Text.Json;
-using Umbraco.Cms.Integrations.Search.Algolia.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Changes;
 using Umbraco.Cms.Core.Sync;
-using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Integrations.Search.Algolia.Builders;
+using Umbraco.Cms.Integrations.Search.Algolia.Migrations;
+using Umbraco.Cms.Integrations.Search.Algolia.Models;
+using Umbraco.Cms.Integrations.Search.Algolia.Services;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
 {

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentCacheRefresherHandler.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentCacheRefresherHandler.cs
@@ -8,6 +8,7 @@ using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.Changes;
 using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Integrations.Search.Algolia.Builders;
 using Umbraco.Cms.Integrations.Search.Algolia.Migrations;
 using Umbraco.Cms.Integrations.Search.Algolia.Models;
@@ -35,6 +36,8 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
 
         private readonly IRecordBuilderFactory _recordBuilderFactory;
 
+        private readonly IUmbracoContextFactory _umbracoContextFactory;
+
         public AlgoliaContentCacheRefresherHandler(
             IServerRoleAccessor serverRoleAccessor,
             ILogger<AlgoliaContentCacheRefresherHandler> logger,
@@ -44,7 +47,8 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
             IUserService userService,
             IPublishedUrlProvider urlProvider,
             IAlgoliaSearchPropertyIndexValueFactory algoliaSearchPropertyIndexValueFactory, 
-            IRecordBuilderFactory recordBuilderFactory)
+            IRecordBuilderFactory recordBuilderFactory,
+            IUmbracoContextFactory umbracoContextFactory)
         {
             _serverRoleAccessor = serverRoleAccessor;
             _contentService = contentService;
@@ -55,6 +59,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
             _urlProvider = urlProvider;
             _algoliaSearchPropertyIndexValueFactory = algoliaSearchPropertyIndexValueFactory;
             _recordBuilderFactory = recordBuilderFactory;
+            _umbracoContextFactory = umbracoContextFactory;
         }
 
         public async Task HandleAsync(ContentCacheRefresherNotification notification, CancellationToken cancellationToken)
@@ -101,7 +106,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
                             .FirstOrDefault(p => p.ContentType.Alias == entity.ContentType.Alias);
                         if (indexConfiguration == null || indexConfiguration.ContentType.Alias != entity.ContentType.Alias) continue;
 
-                        var record = new ContentRecordBuilder(_userService, _urlProvider, _algoliaSearchPropertyIndexValueFactory, _recordBuilderFactory)
+                        var record = new ContentRecordBuilder(_userService, _urlProvider, _algoliaSearchPropertyIndexValueFactory, _recordBuilderFactory, _umbracoContextFactory)
                            .BuildFromContent(entity, (p) => indexConfiguration.Properties.Any(q => q.Alias == p.Alias))
                            .Build();
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
@@ -19,7 +19,7 @@
             WriterName = record.WriterName;
             TemplateId = record.TemplateId;
             Level = record.Level;
-            Path = record.Path;
+            Path = string.Join(",",record.Path);
             Url = record.Url;
             Data = record.Data;
         }
@@ -42,7 +42,7 @@
 
         public int Level { get; set; }
 
-        public List<string> Path { get; set; }
+        public string Path { get; set; }
 
         public string ContentTypeAlias { get; set; }
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
@@ -19,7 +19,7 @@
             WriterName = record.WriterName;
             TemplateId = record.TemplateId;
             Level = record.Level;
-            Path = string.Join(",",record.Path);
+            Path = record.Path;
             Url = record.Url;
             Data = record.Data;
         }
@@ -42,7 +42,7 @@
 
         public int Level { get; set; }
 
-        public string Path { get; set; }
+        public List<string> Path { get; set; }
 
         public string ContentTypeAlias { get; set; }
 


### PR DESCRIPTION
There seems to be an issue running the index builder in background threads like hangfire when you publish nodes with Content Service.

_record.Url = _urlProvider.GetUrl(content.Id) was giving error that the Umbraco Context was not found.

using var ctx = _umbracoContextFactory.EnsureUmbracoContext(); Was set in BuildIndex in SearchController but its missing in AlgoliaContentCacheRefresherHandler.

I changed the code so its passed inside ContentRecordBuilder for it not to be missing again not matter how you call the code.

I reverted the Path change also.