### PR TITLE
Include IProperty with Algolia's index value converter

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/IAlgoliaIndexValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/IAlgoliaIndexValueConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
+﻿using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
     /// <summary>
     /// Defines a custom index converter.
@@ -13,6 +15,6 @@
         /// <summary>
         /// Parses the index values.
         /// </summary>
-        object ParseIndexValues(IEnumerable<object> indexValues);
+        object ParseIndexValues(IProperty property, IEnumerable<object> indexValues);
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoBooleanConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoBooleanConverter.cs
@@ -1,10 +1,12 @@
-﻿namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
+﻿using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
     public class UmbracoBooleanConverter : IAlgoliaIndexValueConverter
     {
         public string Name => Core.Constants.PropertyEditors.Aliases.Boolean;
 
-        public object ParseIndexValues(IEnumerable<object> indexValues)
+        public object ParseIndexValues(IProperty property, IEnumerable<object> indexValues)
         {
             if (indexValues != null && indexValues.Any())
             {

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoDecimalConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoDecimalConverter.cs
@@ -1,10 +1,12 @@
-﻿namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
+﻿using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
     public class UmbracoDecimalConverter : IAlgoliaIndexValueConverter
     {
         public string Name => Core.Constants.PropertyEditors.Aliases.Decimal;
 
-        public object ParseIndexValues(IEnumerable<object> indexValues)
+        public object ParseIndexValues(IProperty property, IEnumerable<object> indexValues)
         {
             if (indexValues != null && indexValues.Any())
             {

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoIntegerConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoIntegerConverter.cs
@@ -1,10 +1,12 @@
-﻿namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
+﻿using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
     public class UmbracoIntegerConverter : IAlgoliaIndexValueConverter
     {
         public string Name => Core.Constants.PropertyEditors.Aliases.Integer;
 
-        public object ParseIndexValues(IEnumerable<object> indexValues)
+        public object ParseIndexValues(IProperty property, IEnumerable<object> indexValues)
         {
             if (indexValues != null && indexValues.Any())
             {

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoMediaPickerConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoMediaPickerConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
@@ -11,7 +12,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 
         public string Name => Core.Constants.PropertyEditors.Aliases.MediaPicker3;
 
-        public object ParseIndexValues(IEnumerable<object> indexValues)
+        public object ParseIndexValues(IProperty property, IEnumerable<object> indexValues)
         {
             var list = new List<string>();
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoTagsConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoTagsConverter.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+﻿using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
     {
         public string Name => Core.Constants.PropertyEditors.Aliases.Tags;
 
-        public object ParseIndexValues(IEnumerable<object> indexValues)
+        public object ParseIndexValues(IProperty property, IEnumerable<object> indexValues)
         {
             if (indexValues != null && indexValues.Any())
             {

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
@@ -37,7 +37,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
             var converter = _converterCollection.FirstOrDefault(p => p.Name == property.PropertyType.PropertyEditorAlias);
             if (converter != null)
             {
-                var result = converter.ParseIndexValues(indexValue.Value);
+                var result = converter.ParseIndexValues(property, indexValue.Value);
                 return new KeyValuePair<string, object>(property.Alias, result);
             }
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Search.Algolia</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>2.1.4</Version>
+		<Version>2.2.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Search.Algolia</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>2.2.0</Version>
+		<Version>2.1.5</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR addressed the issue with RTE detailed [here](https://github.com/umbraco/Umbraco.Cms.Integrations/issues/188) for Umbraco 13, by passing `IProperty` to the parse method of the converters. 

This will make it easier for developers to work directly with the content property. And maybe perhaps just send the `IProperty` instead of the `IEnumerable<object> indexValues`?