### PR TITLE
Updated convertes, index value retrieval and UI fix.

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/js/dashboard.controller.js
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/js/dashboard.controller.js
@@ -382,9 +382,9 @@
                     headline: 'Algolia',
                     message: 'Index built successfully'
                 });
-                vm.loading = false;
             }
         });
+        vm.loading = false;
 
         closeBuildDialog();
     }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/views/dashboard.html
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/views/dashboard.html
@@ -117,10 +117,11 @@
                             <uui-label slot="label">{{ vm.manageIndex.selectedContentType.name }} Properties</uui-label>
                             <uui-icon-registry-essential>
                                 <div class="alg-col-3">
-                                    <uui-card-content-node selectable
+                                    <uui-card-content-node selectable ng-attr-id="{{property.alias}}"
                                                            ng-attr-selected="{{property.selected || undefined}}"
                                                            ng-on-selected="vm.manageIndex.selectProperty(property)"
                                                            ng-on-unselected="vm.manageIndex.removeProperty(property)"
+                                                           ng-on-deselected="vm.manageIndex.removeProperty(property)"
                                                            ng-repeat="property in vm.manageIndex.propertiesList"
                                                            name="{{ property.name }}">
                                         <uui-tag ng-if="property.selected" size="s" slot="tag" color="primary">Selected</uui-tag>

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/IAlgoliaIndexValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/IAlgoliaIndexValueConverter.cs
@@ -13,8 +13,8 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
         string Name { get; }
 
         /// <summary>
-        /// Parses the index values.
+        /// Parses the property's index values.
         /// </summary>
-        object ParseIndexValues(IProperty property, IEnumerable<object> indexValues);
+        object ParseIndexValues(IProperty property);
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoBooleanConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoBooleanConverter.cs
@@ -1,4 +1,5 @@
 ﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Integrations.Search.Algolia.Extensions;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
@@ -6,18 +7,10 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
     {
         public string Name => Core.Constants.PropertyEditors.Aliases.Boolean;
 
-        public object ParseIndexValues(IProperty property, IEnumerable<object> indexValues)
-        {
-            if (indexValues != null && indexValues.Any())
-            {
-                var value = indexValues.FirstOrDefault();
+        public object ParseIndexValues(IProperty property) =>
+            property.TryGetPropertyIndexValue(out string value)
+                ? value.Equals("1")
+                : default;
 
-                return value != null
-                    ? value.Equals(1)
-                    : default;
-            }
-
-            return default(bool);
-        }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoDecimalConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoDecimalConverter.cs
@@ -1,4 +1,5 @@
 ﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Integrations.Search.Algolia.Extensions;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
@@ -6,18 +7,11 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
     {
         public string Name => Core.Constants.PropertyEditors.Aliases.Decimal;
 
-        public object ParseIndexValues(IProperty property, IEnumerable<object> indexValues)
-        {
-            if (indexValues != null && indexValues.Any())
-            {
-                var value = indexValues.FirstOrDefault();
-
-                return value != null
-                    ? decimal.Parse(value.ToString())
-                    : default;
-            }
-
-            return default(decimal);
-        }
+        public object ParseIndexValues(IProperty property) =>
+            property.TryGetPropertyIndexValue(out string value)
+            ? (decimal.TryParse(value.ToString(), out var result)
+                ? result
+                : default)
+            : default;
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoIntegerConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoIntegerConverter.cs
@@ -1,4 +1,5 @@
 ﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Integrations.Search.Algolia.Extensions;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
@@ -6,16 +7,11 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
     {
         public string Name => Core.Constants.PropertyEditors.Aliases.Integer;
 
-        public object ParseIndexValues(IProperty property, IEnumerable<object> indexValues)
-        {
-            if (indexValues != null && indexValues.Any())
-            {
-                var value = indexValues.FirstOrDefault();
-
-                return value ?? default(int);
-            }
-
-            return default(int);
-        }
+        public object ParseIndexValues(IProperty property) =>
+            property.TryGetPropertyIndexValue(out string value)
+            ? (int.TryParse(value.ToString(), out var result)
+                ? result
+                : default)
+            : default;
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoMediaPickerConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoMediaPickerConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Integrations.Search.Algolia.Extensions;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
@@ -12,15 +13,16 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 
         public string Name => Core.Constants.PropertyEditors.Aliases.MediaPicker3;
 
-        public object ParseIndexValues(IProperty property, IEnumerable<object> indexValues)
+        public object ParseIndexValues(IProperty property)
         {
             var list = new List<string>();
 
-            var parsedIndexValue = ParseIndexValue(indexValues);
+            if (!property.TryGetPropertyIndexValue(out string value))
+            {
+                return list;
+            }
 
-            if (string.IsNullOrEmpty(parsedIndexValue)) return list;
-
-            var inputMedia = JsonSerializer.Deserialize<IEnumerable<MediaItem>>(parsedIndexValue);
+            var inputMedia = JsonSerializer.Deserialize<IEnumerable<MediaItem>>(value);
 
             if (inputMedia == null) return string.Empty;
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoTagsConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/UmbracoTagsConverter.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Models;
+﻿using System.Text.Json;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Integrations.Search.Algolia.Extensions;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
 {
@@ -6,11 +8,17 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
     {
         public string Name => Core.Constants.PropertyEditors.Aliases.Tags;
 
-        public object ParseIndexValues(IProperty property, IEnumerable<object> indexValues)
+        public object ParseIndexValues(IProperty property)
         {
-            if (indexValues != null && indexValues.Any())
+            if (!property.TryGetPropertyIndexValue(out string value))
             {
-                return indexValues;
+                return Enumerable.Empty<string>();
+            }
+
+            var valuesArr = JsonSerializer.Deserialize<List<string>>(value);
+            if (valuesArr != null && valuesArr.Any())
+            {
+                return valuesArr.Select(p => p);
             }
 
             return Enumerable.Empty<string>();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Extensions/ConverterExtensions.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Extensions/ConverterExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Extensions
+{
+    public static class ConverterExtensions
+    {
+        public static bool TryGetPropertyIndexValue(this IProperty property, out string value)
+        {
+            bool success = true;
+            value = string.Empty;
+
+            if (property.GetValue() is null || string.IsNullOrEmpty(property.GetValue().ToString()))
+            {
+                success = false;
+            }
+
+            value = property.GetValue().ToString();
+
+            return success;
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
@@ -28,18 +28,18 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
                 return default;
             }
 
-            var indexValues = propertyEditor.PropertyIndexValueFactory.GetIndexValues(property, culture, null, true);
+            var converter = _converterCollection.FirstOrDefault(p => p.Name == property.PropertyType.PropertyEditorAlias);
+            if (converter != null)
+            {
+                var result = converter.ParseIndexValues(property);
+                return new KeyValuePair<string, object>(property.Alias, result);
+            }
+
+            IEnumerable<KeyValuePair<string, IEnumerable<object>>> indexValues = propertyEditor.PropertyIndexValueFactory.GetIndexValues(property, culture, null, true);
 
             if (indexValues == null || !indexValues.Any()) return new KeyValuePair<string, object>(property.Alias, string.Empty);
 
             var indexValue = indexValues.First();
-
-            var converter = _converterCollection.FirstOrDefault(p => p.Name == property.PropertyType.PropertyEditorAlias);
-            if (converter != null)
-            {
-                var result = converter.ParseIndexValues(property, indexValue.Value);
-                return new KeyValuePair<string, object>(property.Alias, result);
-            }
 
             return new KeyValuePair<string, object>(property.Alias, indexValue.Value);
         }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
@@ -1,6 +1,6 @@
 ﻿using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Integrations.Search.Algolia.Providers;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Services
@@ -8,20 +8,28 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
     public class AlgoliaSearchPropertyIndexValueFactory : IAlgoliaSearchPropertyIndexValueFactory
     {
         private readonly PropertyEditorCollection _propertyEditorsCollection;
-
         private readonly ConverterCollection _converterCollection;
+
+        private readonly ILocalizationService _localizationService;
+        private readonly IContentTypeService _contentTypeService;
 
         public AlgoliaSearchPropertyIndexValueFactory(
             PropertyEditorCollection propertyEditorCollection,
-            ConverterCollection converterCollection)
+            ConverterCollection converterCollection,
+            ILocalizationService localizationService,
+            IContentTypeService contentTypeService)
         {
             _propertyEditorsCollection = propertyEditorCollection;
-
             _converterCollection = converterCollection;
+            _localizationService = localizationService;
+            _contentTypeService = contentTypeService;
         }
 
         public virtual KeyValuePair<string, object> GetValue(IProperty property, string culture)
         {
+            var availableCultures = _localizationService.GetAllLanguages().Select(p => p.IsoCode);
+            IDictionary<Guid, IContentType> contentTypeDictionary = _contentTypeService.GetAll().ToDictionary(x => x.Key);
+
             var propertyEditor = _propertyEditorsCollection.FirstOrDefault(p => p.Alias == property.PropertyType.PropertyEditorAlias);
             if (propertyEditor == null)
             {
@@ -35,8 +43,22 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
                 return new KeyValuePair<string, object>(property.Alias, result);
             }
 
-            IEnumerable<KeyValuePair<string, IEnumerable<object>>> indexValues = propertyEditor.PropertyIndexValueFactory.GetIndexValues(property, culture, null, true);
-
+            IEnumerable<KeyValuePair<string, IEnumerable<object>>> indexValues =
+#if NET6_0 || NET7_0
+                propertyEditor.PropertyIndexValueFactory.GetIndexValues(
+                    property, 
+                    culture, 
+                    null, 
+                    true);
+#else
+                propertyEditor.PropertyIndexValueFactory.GetIndexValues(
+                    property,
+                    culture,
+                    null,
+                    true,
+                    availableCultures,
+                    contentTypeDictionary);
+#endif
             if (indexValues == null || !indexValues.Any()) return new KeyValuePair<string, object>(property.Alias, string.Empty);
 
             var indexValue = indexValues.First();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Search.Algolia</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>2.1.5</Version>
+		<Version>2.2.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR addresses some of the issues raised [here](https://github.com/umbraco/Umbraco.Cms.Integrations/issues/191), which impacted the dashboard UI and data indexing.

Two changes are included with this minor release, one to the UI fixing the card deselected event, and the main one to the way converters behave.

I have removed the `indexValues` parameter of `IAlgoliaIndexValueConverter.ParseIndexValues` and work directly with the property. The `IProperty` parameter was included with the previous update of Algolia, and it would make sense to use it directly and not the index values returned by the CMS index value factory. 

To that extend, I moved the converters to run first, then to move to the editor's index value factory from CMS.