### PR TITLE
Added support for displaying prices and filtering on products picked

### DIFF
--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
@@ -38,7 +38,7 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Editors
             if (source == null) return null;
 
             return source.ToString()
-                .Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(long.Parse)
                 .ToArray();
         }
@@ -60,7 +60,20 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Editors
                                Id = p.Id,
                                Title = p.Title,
                                Body = p.Body,
-                               Image = p.Image?.Src
+                               Image = p.Image?.Src,
+                               Tags = p.Tags,
+                               ProductType = p.ProductType,
+                               PublishedScope = p.PublishedScope,
+                               Status = p.Status,
+                               Variants = from v in p.Variants
+                                          select new VariantViewModel
+                                          {
+                                              InventoryQuantity = v.InventoryQuantity,
+                                              Position = v.Position,
+                                              Price = v.Price,
+                                              Sku = v.Sku,
+                                              Taxable = v.Taxable
+                                          }
                            };
 
             return products.ToList();

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/Dtos/ProductDto.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/Dtos/ProductDto.cs
@@ -1,6 +1,5 @@
-﻿using System.Collections.Generic;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Umbraco.Cms.Integrations.Commerce.Shopify.Models.Dtos
 {
@@ -29,6 +28,12 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Models.Dtos
 
         [JsonProperty("image")]
         public ProductImageDto Image { get; set; }
+
+        [JsonProperty("product_type")]
+        public string ProductType { get; set; }
+
+        [JsonProperty("published_scope")]
+        public string PublishedScope { get; set; }
     }
 
 

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/Dtos/ProductVariantDto.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/Dtos/ProductVariantDto.cs
@@ -18,5 +18,9 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Models.Dtos
 
         [JsonProperty("inventory_quantity")]
         public int InventoryQuantity { get; set; }
+
+        [JsonProperty("taxable")]
+        public bool Taxable { get; set; }
+
     }
 }

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/ViewModels/ProductViewModel.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/ViewModels/ProductViewModel.cs
@@ -1,14 +1,19 @@
 ﻿
+using System.Collections.Generic;
+
 namespace Umbraco.Cms.Integrations.Commerce.Shopify.Models.ViewModels
 {
     public class ProductViewModel
     {
         public long Id { get; set; }
-
         public string Title { get; set; }
-
         public string Body { get; set; }
 
         public string Image { get; set; }
+        public string ProductType { get; set; }
+        public string Tags { get; set; }
+        public string Status { get; set; }
+        public string PublishedScope { get; set; }
+        public IEnumerable<VariantViewModel> Variants { get; set; }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/ViewModels/VariantViewModel.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/ViewModels/VariantViewModel.cs
@@ -1,0 +1,13 @@
+﻿
+namespace Umbraco.Cms.Integrations.Commerce.Shopify.Models.ViewModels
+{
+    public class VariantViewModel
+    {
+        public string Price { get; set; }
+        public string Sku { get; set; }
+        public int Position { get; set; }
+        public int InventoryQuantity { get; set; }
+        public bool Taxable { get; set; }
+
+    }
+}


### PR DESCRIPTION
Hello

We have a requirement to display the price of products which have been picked from shopify. This PR is to help resolve this.

I also think the fact that product type and tags are missing from the data returned by the integration means it's not possible in Umbraco to create searches that use the tags. I did consider mapping tags to a `ienumerable<string>` and am happy to do this.

Finally I have added Status in as the integration could result in a mapping to products that are no longer published. I did consider mapping `status` to https://shopify.dev/docs/api/admin-graphql/2024-04/enums/ProductStatus and can do, but also it would mean the API would need further work if future status' were added.