### PR TITLE
Improved support for accessibility and added handle

### DIFF
--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
@@ -60,10 +60,11 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Editors
                                Id = p.Id,
                                Title = p.Title,
                                Body = p.Body,
-                               Image = p.Image?.Src,
+                               ProductImage = p.Image != null ? new ProductImage { Src = p.Image.Src, Alt = p.Image.Alt } : null,
                                Tags = p.Tags,
                                ProductType = p.ProductType,
                                PublishedScope = p.PublishedScope,
+                               Handle = p.Handle,
                                Status = p.Status,
                                Variants = from v in p.Variants
                                           select new VariantViewModel

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/Dtos/ProductDto.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/Dtos/ProductDto.cs
@@ -34,6 +34,9 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Models.Dtos
 
         [JsonProperty("published_scope")]
         public string PublishedScope { get; set; }
+
+        [JsonProperty("handle")]
+        public string Handle { get; set; }
     }
 
 

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/Dtos/ProductImageDto.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/Dtos/ProductImageDto.cs
@@ -6,5 +6,8 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Models.Dtos
     {
         [JsonProperty("src")]
         public string Src { get; set; }
+
+        [JsonProperty("alt")]
+        public string Alt { get; set; }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/ViewModels/ProductImage.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/ViewModels/ProductImage.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Integrations.Commerce.Shopify.Models.ViewModels
+{
+    public class ProductImage
+    {
+        public string Src { get; set; }
+        public string Alt { get; set; }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/ViewModels/ProductViewModel.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Models/ViewModels/ProductViewModel.cs
@@ -9,11 +9,13 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Models.ViewModels
         public string Title { get; set; }
         public string Body { get; set; }
 
-        public string Image { get; set; }
+        public string Image => ProductImage.Src;
+        public ProductImage ProductImage { get; set; }
         public string ProductType { get; set; }
         public string Tags { get; set; }
         public string Status { get; set; }
         public string PublishedScope { get; set; }
+        public string Handle { get; set; }
         public IEnumerable<VariantViewModel> Variants { get; set; }
     }
 }


### PR DESCRIPTION
Hello

As the current code base stands surfacing just image means that any integrations can not use the alt text on that image, this is now surfaced. I have left the existing Image Property in so as not to break any code.

I have also added handle, https://www.howcommerce.com/shopify-handle/ to enable support for integrations to allow people to click straight through to the product

---
_This item has been added to our backlog AB#42563_