### PR TITLE
Add feature for manually exchange an authorization code for a token

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/css/styles.css
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/css/styles.css
@@ -19,11 +19,11 @@
     background-color: #eee;
 }
 
-    .hsFormsList a i {
-        position: absolute;
-        top: .4rem;
-        left: .25rem;
-    }
+.hsFormsList a i {
+    position: absolute;
+    top: .4rem;
+    left: .25rem;
+}
 
 .hsFormsList .formLine {
     display: block;
@@ -33,4 +33,11 @@
     padding-top: 4px;
 }
 
+#authCode {
+    display: none;
+}
 
+#inAuthCode {
+    width: 40%;
+    margin: 0 auto;
+}

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/views/settings.html
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/App_Plugins/UmbracoCms.Integrations/Crm/Hubspot/views/settings.html
@@ -18,4 +18,13 @@
                     disabled="!vm.oauthSetup.isConnected">
         </umb-button>
     </div>
+    <div id="authCode" class="mt3">
+        <input id="inAuthCode" type="text" ng-model="vm.authCode" placeholder="Authorization code" no-dirty-check />
+        <umb-button action="vm.onAuthorize()"
+                    type="button"
+                    button-style="primary"
+                    state="init"
+                    label="Authorize">
+        </umb-button>
+    </div>
 </div>

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Crm.Hubspot</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>4.0.2</Version>
+		<Version>4.0.3</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
@@ -58,10 +58,6 @@
 			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
 			<CopyToPublishDirectory>Always</CopyToPublishDirectory>
 		</Content>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <None Remove="App_Plugins\UmbracoCms.Integrations\Crm\Hubspot\js\hubspotauthorization.directive.js" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Current PR adds a feature to the `HubSpot Forms` integration that allow users to manually exchange an authorization code for an access token.

A particular use case has created an issue during the `OAuth2` flow. When connecting to the service without having any cookie credentials of that service, the browser removes the `window.opener` property resulting in the authorization window not closing and an inability to retrieve the access token.

To address this, we are _watching_ the window for 7 seconds, and if it remains open, we are displaying an input field allowing users to exchange the authorization code for an access token.

A small demo [here](https://us02web.zoom.us/clips/share/G5-9125ZA4_jCxKff8Jcq7JjYsHeHalDuLvxOArqfnc7VdBDF5TGuUgHPPvNMrGaD2kRcYBoHJ2kk0cpb_twzkOg6A.ySbmD8AUobKfd0I-).

Next steps will be to apply the same change to `Dynamics` and `Google`.

