### PR TITLE
MNTP index value converter + fixing issue in helper function

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/SimpleMultinodeTreePickerIndexValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/SimpleMultinodeTreePickerIndexValueConverter.cs
@@ -1,0 +1,68 @@
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
+{
+    public class SimpleMultinodeTreePickerIndexValueConverter : IAlgoliaIndexValueConverter
+    {
+        public string Name => Core.Constants.PropertyEditors.Aliases.MultiNodeTreePicker;
+
+        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly IContentService _contentService;
+
+
+        public SimpleMultinodeTreePickerIndexValueConverter(
+            IUmbracoContextAccessor umbracoContextAccessor,
+            IContentService contentService)
+        {
+            _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
+            _contentService = contentService ?? throw new ArgumentNullException(nameof(contentService));
+        }
+
+
+        public object ParseIndexValues(IProperty property)
+        {
+
+            if (property.Values.Count == 0)
+                return Enumerable.Empty<string>();
+
+            var value = property.GetValue()?.ToString();
+
+            if (string.IsNullOrEmpty(value))
+                return Enumerable.Empty<string>();
+
+            var udiStrings = value.Split(',');
+
+            var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
+
+            var toReturn = new List<string>();
+
+            foreach (var udiString in udiStrings)
+            {
+                var cacheName = umbracoContext.Content.GetById(UdiParser.Parse(udiString))?.Name;
+                
+                if (cacheName != null)
+                {
+                    toReturn.Add(cacheName);
+                    continue;
+                }
+
+                else
+                {
+                    var guid = new GuidUdi(new Uri(udiString)).Guid;
+                    var dbName = _contentService.GetById(guid)?.Name;
+
+                    if (dbName != null)
+                    {
+                        toReturn.Add(dbName);
+                    }
+                }
+            }
+            return toReturn;
+        }
+
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/SimpleMultinodeTreePickerIndexValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Converters/SimpleMultinodeTreePickerIndexValueConverter.cs
@@ -13,7 +13,6 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
         private readonly IContentService _contentService;
 
-
         public SimpleMultinodeTreePickerIndexValueConverter(
             IUmbracoContextAccessor umbracoContextAccessor,
             IContentService contentService)
@@ -22,10 +21,8 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
             _contentService = contentService ?? throw new ArgumentNullException(nameof(contentService));
         }
 
-
         public object ParseIndexValues(IProperty property)
         {
-
             if (property.Values.Count == 0)
                 return Enumerable.Empty<string>();
 
@@ -61,6 +58,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Converters
                     }
                 }
             }
+
             return toReturn;
         }
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Extensions/ConverterExtensions.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Extensions/ConverterExtensions.cs
@@ -12,6 +12,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Extensions
             if (property.GetValue() is null || string.IsNullOrEmpty(property.GetValue().ToString()))
             {
                 success = false;
+                return success;
             }
 
             value = property.GetValue().ToString();


### PR DESCRIPTION
There was an issue with the TryGetPropertyIndexValue where we could still get a NullRef exception for some edge cases that is fixed now. 

I also added a Index value converter for MNTP based on the name that use cache and db call when needed. As it can impact the database I left it outside of the list of default converters so people can decide to pick it or not. Tested in v10. 