### PR TITLE
geo loc properties

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Models/GeolocProperties.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Models/GeolocProperties.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Models
+{
+    public class GeolocProperties
+    {
+        [JsonProperty("lat")]
+        public double Latitude { get; set; }
+
+        [JsonProperty("lng")]
+        public double Longitude { get; set; }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Record.cs
@@ -1,10 +1,13 @@
-﻿namespace Umbraco.Cms.Integrations.Search.Algolia.Models
+﻿using Newtonsoft.Json;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Models
 {
     public class Record
     {
         public Record()
         {
             Data = new Dictionary<string, object>();
+            Geoloc = new List<GeolocProperties>();
         }
 
         public Record(Record record)
@@ -22,6 +25,7 @@
             Path = record.Path;
             Url = record.Url;
             Data = record.Data;
+            Geoloc = record.Geoloc;
         }
 
         public string ObjectID { get; set; }
@@ -57,6 +61,9 @@
         public string ContentTypeAlias { get; set; }
 
         public string Url { get; set; }
+
+        [JsonProperty("_geoloc")]
+        public List<GeolocProperties> Geoloc { get; set; }
 
         public Dictionary<string, object> Data { get; set; }
     }


### PR DESCRIPTION
Based on the issue here: https://github.com/umbraco/Umbraco.Cms.Integrations/issues/213

Based on the geo location feature in Algolia, we need a root level property _geoloc to contain geo location data to enable geo location search. It cannot be inside the Data property as it is a simple Dictionary<string, object> with no way to tell that the data needs to be at the root level (all the properties inside the Data dictionary are serialized as data.prop)

https://www.algolia.com/doc/guides/managing-results/refine-results/geolocation/#enabling-geo-search-by-adding-geolocation-data-to-records