### PR TITLE
Pass content item to geolocation method

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Builders/ContentRecordBuilder.cs
@@ -70,7 +70,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Builders
             _record.Path = content.Path.Split(',').ToList();
             _record.ContentTypeAlias = content.ContentType.Alias;
             _record.Url = _urlProvider.GetUrl(content.Id);
-            _record.GeolocationData = _algoliaGeolocationProvider.GetGeolocationAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            _record.GeolocationData = _algoliaGeolocationProvider.GetGeolocationAsync(content).ConfigureAwait(false).GetAwaiter().GetResult();
             _record.Data = new();
 
             if (content.PublishedCultures.Count() > 0)

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaIndexService.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaIndexService.cs
@@ -32,7 +32,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
                     : new List<Record> {
                         new Record {
                             ObjectID = Guid.NewGuid().ToString(),
-                            GeolocationData = await _algoliaGeolocationProvider.GetGeolocationAsync(),
+                            GeolocationData = new List<GeolocationEntity>(),
                             Data = new Dictionary<string, object>()}
                     }, autoGenerateObjectId: false);
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaIndexService.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaIndexService.cs
@@ -11,12 +11,10 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
     public class AlgoliaIndexService : IAlgoliaIndexService
     {
         private readonly AlgoliaSettings _settings;
-        private readonly IAlgoliaGeolocationProvider _algoliaGeolocationProvider;
 
-        public AlgoliaIndexService(IOptions<AlgoliaSettings> options, IAlgoliaGeolocationProvider algoliaGeolocationProvider)
+        public AlgoliaIndexService(IOptions<AlgoliaSettings> options)
         {
             _settings = options.Value;
-            _algoliaGeolocationProvider = algoliaGeolocationProvider;
         }
 
         public async Task<Result> PushData(string name, List<Record> payload = null)
@@ -32,7 +30,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
                     : new List<Record> {
                         new Record {
                             ObjectID = Guid.NewGuid().ToString(),
-                            GeolocationData = new List<GeolocationEntity>(),
+                            GeolocationData = null,
                             Data = new Dictionary<string, object>()}
                     }, autoGenerateObjectId: false);
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaNullGeolocationProvider.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaNullGeolocationProvider.cs
@@ -1,9 +1,10 @@
-﻿using Umbraco.Cms.Integrations.Search.Algolia.Models;
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Integrations.Search.Algolia.Models;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 {
     public class AlgoliaNullGeolocationProvider : IAlgoliaGeolocationProvider
     {
-        public async Task<List<GeolocationEntity>> GetGeolocationAsync() => null;
+        public async Task<List<GeolocationEntity>> GetGeolocationAsync(IContent content) => null;
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/IAlgoliaGeolocationProvider.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/IAlgoliaGeolocationProvider.cs
@@ -1,9 +1,10 @@
-﻿using Umbraco.Cms.Integrations.Search.Algolia.Models;
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Integrations.Search.Algolia.Models;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 {
     public interface IAlgoliaGeolocationProvider
     {
-        Task<List<GeolocationEntity>> GetGeolocationAsync();
+        Task<List<GeolocationEntity>> GetGeolocationAsync(IContent content);
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Search.Algolia</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>2.3.0</Version>
+		<Version>2.3.1</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
This PR is a follow up to [this](https://github.com/umbraco/Umbraco.Cms.Integrations/issues/213#issuecomment-2360663317) comment, realizing that another use case I skipped was the one where the localization information might come from content.

To address this, I am passing an `IContent`  parameter to the provider method.