### PR TITLE
Fix property selection on persisting index data

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Api/Management/Controllers/SaveIndexController.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Api/Management/Controllers/SaveIndexController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Json;
+using Umbraco.Cms.Integrations.Search.Algolia.Extensions;
 using Umbraco.Cms.Integrations.Search.Algolia.Migrations;
 using Umbraco.Cms.Integrations.Search.Algolia.Models;
 using Umbraco.Cms.Integrations.Search.Algolia.Services;
@@ -31,8 +32,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Api.Management.Controllers
             {
                 Id = index.Id,
                 Name = index.Name,
-                SerializedData = JsonSerializer.Serialize(index.ContentData
-                        .Where(p => p.Selected && p.Properties.Any(q => q.Selected))),
+                SerializedData = JsonSerializer.Serialize(index.ContentData.FilterByPropertySelected()),
                 Date = DateTime.Now
             });
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Extensions/ContentTypeExtensions.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Extensions/ContentTypeExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Umbraco.Cms.Integrations.Search.Algolia.Models.ContentTypeDtos;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Extensions
+{
+    public static class ContentTypeExtensions
+    {
+        public static IEnumerable<ContentTypeDto> FilterByPropertySelected(this IEnumerable<ContentTypeDto> source)
+        {
+            foreach (var item in source)
+            {
+                if (!item.Selected) continue;
+
+                var contentType = item;
+
+                contentType.Properties = item.Properties.Where(x => x.Selected);
+
+                if (!contentType.Properties.Any()) continue;
+
+                yield return contentType;
+            }
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaSearchPropertyIndexValueFactory.cs
@@ -1,6 +1,7 @@
-﻿using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.PublishedContent;
+﻿using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Integrations.Search.Algolia.Providers;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Services
@@ -11,13 +12,23 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 
         private readonly ConverterCollection _converterCollection;
 
+        private readonly IContentTypeService _contentTypeService;
+
+        private readonly ILogger<AlgoliaSearchPropertyIndexValueFactory> _logger;
+
         public AlgoliaSearchPropertyIndexValueFactory(
             PropertyEditorCollection propertyEditorCollection,
-            ConverterCollection converterCollection)
+            ConverterCollection converterCollection,
+            IContentTypeService contentTypeService,
+            ILogger<AlgoliaSearchPropertyIndexValueFactory> logger)
         {
             _propertyEditorsCollection = propertyEditorCollection;
 
             _converterCollection = converterCollection;
+
+            _contentTypeService = contentTypeService;
+
+            _logger = logger;
         }
 
         public virtual KeyValuePair<string, object> GetValue(IProperty property, string culture)
@@ -28,20 +39,36 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
                 return default;
             }
 
-            var indexValues = propertyEditor.PropertyIndexValueFactory.GetIndexValues(property, culture, null, true, Enumerable.Empty<string>(), null);
+            Dictionary<Guid, IContentType> contentTypeDictionary = _contentTypeService.GetAll().ToDictionary(x => x.Key);
 
-            if (indexValues == null || !indexValues.Any()) return new KeyValuePair<string, object>(property.Alias, string.Empty);
-
-            var indexValue = indexValues.First();
-
-            var converter = _converterCollection.FirstOrDefault(p => p.Name == property.PropertyType.PropertyEditorAlias);
-            if (converter != null)
+            try
             {
-                var result = converter.ParseIndexValues(property, indexValue.Value);
-                return new KeyValuePair<string, object>(property.Alias, result);
-            }
+                var indexValues = propertyEditor.PropertyIndexValueFactory.GetIndexValues(
+                    property,
+                    culture,
+                    null,
+                    true,
+                    Enumerable.Empty<string>(),
+                    contentTypeDictionary);
 
-            return new KeyValuePair<string, object>(property.Alias, indexValue.Value);
+                if (indexValues == null || !indexValues.Any()) return new KeyValuePair<string, object>(property.Alias, string.Empty);
+
+                var indexValue = indexValues.First();
+
+                var converter = _converterCollection.FirstOrDefault(p => p.Name == property.PropertyType.PropertyEditorAlias);
+                if (converter != null)
+                {
+                    var result = converter.ParseIndexValues(property, indexValue.Value);
+                    return new KeyValuePair<string, object>(property.Alias, result);
+                }
+
+                return new KeyValuePair<string, object>(property.Alias, indexValue.Value);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to get values for {property.Alias}: {ex.Message}");
+                return default;
+            }
         }
     }
 }


### PR DESCRIPTION
Current PR addresses this issue: #223 , and fixes two problems:
* Selection of properties for a content type: in the current structure of the backoffice, when an index is saved, all the properties of the a selected content type are sent to the server; only the `selected` flag would make a difference (for reference, in the v13 version, selected properties are pushed into an array, the endpoint receiving only the selected properties). 
    * **Solution**: use an extension method called `FilterByPropertySelected` to persist into the database table only the actual selected properties.
* With the block property editors `Umbraco.BlockGrid` and `Umbraco.BlockList`, a `null` reference exception was thrown by the `AlgoliaSearchPropertyIndexValueFactory` when trying to get the value. The reason for this was the sending of a `null` value for the  `contentTypeDictionary` parameter of `propertyEditor.PropertyIndexValueFactory.GetIndexValues`. After checking the CMS source, I found this being used in similar scenarios, which also fixed the issue of Algolia: 
`Dictionary<Guid, IContentType> contentTypeDictionary = _contentTypeService.GetAll().ToDictionary(x => x.Key);`

Additionally, I've considered to wrap it in a `try / catch` block, so the indexing of a content node would not fail if a complex type throws an exception, and to log the error in this case. 

Update will go under a new minor version - `3.2.0`.