### PR TITLE
Fix dictionary duplicate key and multinode null reference.

### DIFF
--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/Parsers/MultiNodeTreePickerParser.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/Parsers/MultiNodeTreePickerParser.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Services.Parsers
 
             var items = contentProperty.GetValue() as IEnumerable<IPublishedContent>;
 
-            return items.Any()
+            return items != null && items.Any()
                 ? string.Join(", ", items.Select(p => p.Name))
                 : string.Empty;
         }

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/ZapierContentService.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/ZapierContentService.cs
@@ -41,6 +41,11 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Services
 
                 var parser = _zapierContentFactory.Create(contentProperty.PropertyType.EditorAlias);
 
+                if (contentDict.ContainsKey(propertyType.Alias))
+                {
+                    continue;
+                }
+
                 contentDict.Add(propertyType.Alias, parser.GetValue(contentProperty));
             }
 
@@ -58,6 +63,11 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Services
 
             foreach (var prop in contentNode.Properties)
             {
+                if (contentDict.ContainsKey(prop.Alias))
+                {
+                    continue;
+                }
+
                 contentDict.Add(prop.Alias, prop.Id == 0 || prop.Values.Count == 0 ? string.Empty : prop.GetValue().ToString());
             }
 

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Umbraco.Cms.Integrations.Automation.Zapier.csproj
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Umbraco.Cms.Integrations.Automation.Zapier.csproj
@@ -9,7 +9,7 @@
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Automation.Zapier</PackageProjectUrl>
 		<Product>Umbraco.Cms.Integrations.Automation.Zapier</Product>
-		<Version>1.3.0</Version>
+		<Version>1.3.1</Version>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
 		<PackageIcon>zapier.png</PackageIcon>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>


### PR DESCRIPTION
Current PR addresses issues raised while working with Zapier on umbraco.com.

* First fix addresses the use case when a content type might use a property called `publishDate` (e.g. a blog post), which throws an `ArgumentException` due to the existence of the key in the dictionary.
* Secondly, I've added a check for `MultiNodeTreePickerParser` to ensure no `NULL` value exists.