### PR TITLE
Fix dictionary duplicate key and multinode null reference.

### DIFF
--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/Parsers/MultiNodeTreePickerParser.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/Parsers/MultiNodeTreePickerParser.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Umbraco.Cms.Core.Models.PublishedContent;
+﻿using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Umbraco.Cms.Integrations.Automation.Zapier.Services.Parsers
 {
@@ -12,7 +10,7 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Services.Parsers
 
             var items = contentProperty.GetValue() as IEnumerable<IPublishedContent>;
 
-            return items.Any()
+            return items != null && items.Any()
                 ? string.Join(", ", items.Select(p => p.Name))
                 : string.Empty;
         }

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/ZapierContentService.cs
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Services/ZapierContentService.cs
@@ -31,6 +31,11 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Services
 
                 var parser = _zapierContentFactory.Create(contentProperty.PropertyType.EditorAlias);
 
+                if (contentDict.ContainsKey(propertyType.Alias))
+                {
+                    continue;
+                }
+
                 contentDict.Add(propertyType.Alias, parser.GetValue(contentProperty));
             }
 
@@ -48,6 +53,11 @@ namespace Umbraco.Cms.Integrations.Automation.Zapier.Services
 
             foreach (var prop in contentNode.Properties)
             {
+                if (contentDict.ContainsKey(prop.Alias))
+                {
+                    continue;
+                }
+
                 contentDict.Add(prop.Alias, prop.Id == 0 || prop.Values.Count == 0 ? string.Empty : prop.GetValue().ToString());
             }
 

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Umbraco.Cms.Integrations.Automation.Zapier.csproj
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Umbraco.Cms.Integrations.Automation.Zapier.csproj
@@ -17,7 +17,7 @@
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Automation.Zapier</PackageProjectUrl>
 		<Product>Umbraco.Cms.Integrations.Automation.Zapier</Product>
-		<Version>2.0.0</Version>
+		<Version>2.0.1</Version>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
 		<PackageIcon>zapier.png</PackageIcon>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>


### PR DESCRIPTION
Current PR adds the changes detailed in #229 , but for Umbraco 14.