### PR TITLE
Shopify cache level

### DIFF
--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Configuration/ShopifySettings.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Configuration/ShopifySettings.cs
@@ -1,4 +1,9 @@
 ﻿using System.Collections.Specialized;
+#if NETCOREAPP
+using Umbraco.Cms.Core.PropertyEditors;
+#else
+using Umbraco.Core.PropertyEditors;
+#endif
 
 namespace Umbraco.Cms.Integrations.Commerce.Shopify.Configuration
 {
@@ -6,7 +11,7 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Configuration
     {
         public ShopifySettings()
         {
-            
+
         }
 
         public ShopifySettings(NameValueCollection appSettings)
@@ -17,6 +22,26 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Configuration
             UseUmbracoAuthorization = bool.TryParse(appSettings[Constants.Configuration.UmbracoCmsIntegrationsCommerceShopifyUseUmbracoAuthorizationKey], out var key)
                ? key
                : true;
+
+            // Enum.TryParse introduced in .NET site is .NETFramework and .NET Core, same logic will work for both
+            switch (appSettings[Constants.Configuration.UmbracoCmsIntegrationsCommerceShopifyPropertyCacheLevel])
+            {
+                case "Unknown":
+                    CacheLevel = PropertyCacheLevel.Unknown;
+                    break;
+                case "Element":
+                    CacheLevel = PropertyCacheLevel.Element;
+                    break;
+                case "Elements":
+                    CacheLevel = PropertyCacheLevel.Elements;
+                    break;
+                case "None":
+                    CacheLevel = PropertyCacheLevel.None;
+                    break;
+                default:
+                    CacheLevel = PropertyCacheLevel.Snapshot;
+                    break;
+            }
         }
 
         public string ApiVersion { get; set; }
@@ -26,5 +51,7 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Configuration
         public string AccessToken { get; set; }
 
         public bool UseUmbracoAuthorization { get; set; } = true;
+
+        public PropertyCacheLevel CacheLevel { get; set; } = PropertyCacheLevel.Snapshot;
     }
 }

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Configuration/ShopifySettings.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Configuration/ShopifySettings.cs
@@ -27,19 +27,19 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Configuration
             switch (appSettings[Constants.Configuration.UmbracoCmsIntegrationsCommerceShopifyPropertyCacheLevel])
             {
                 case "Unknown":
-                    CacheLevel = PropertyCacheLevel.Unknown;
+                    PropertyCacheLevel = PropertyCacheLevel.Unknown;
                     break;
                 case "Element":
-                    CacheLevel = PropertyCacheLevel.Element;
+                    PropertyCacheLevel = PropertyCacheLevel.Element;
                     break;
                 case "Elements":
-                    CacheLevel = PropertyCacheLevel.Elements;
+                    PropertyCacheLevel = PropertyCacheLevel.Elements;
                     break;
                 case "None":
-                    CacheLevel = PropertyCacheLevel.None;
+                    PropertyCacheLevel = PropertyCacheLevel.None;
                     break;
                 default:
-                    CacheLevel = PropertyCacheLevel.Snapshot;
+                    PropertyCacheLevel = PropertyCacheLevel.Snapshot;
                     break;
             }
         }
@@ -52,6 +52,6 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Configuration
 
         public bool UseUmbracoAuthorization { get; set; } = true;
 
-        public PropertyCacheLevel CacheLevel { get; set; } = PropertyCacheLevel.Snapshot;
+        public PropertyCacheLevel PropertyCacheLevel { get; set; } = PropertyCacheLevel.Snapshot;
     }
 }

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Constants.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Constants.cs
@@ -47,6 +47,9 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify
             public const string UmbracoCmsIntegrationsCommerceShopifyScopesKey = "Umbraco.Cms.Integrations.Commerce.Shopify.Scopes";
 
             public const string UmbracoCmsIntegrationsCommerceShopifyTokenEndpointKey = "Umbraco.Cms.Integrations.Commerce.Shopify.TokenEndpoint";
+
+            public const string UmbracoCmsIntegrationsCommerceShopifyPropertyCacheLevel =
+                "Umbraco.Cms.Integrations.Commerce.Shopify.PropertyCacheLevel";
         }
 
         public static class PropertyEditors

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
@@ -4,13 +4,16 @@ using System.Linq;
 using System.Threading.Tasks;
 using Umbraco.Cms.Integrations.Commerce.Shopify.Models.ViewModels;
 using Umbraco.Cms.Integrations.Commerce.Shopify.Services;
+using Umbraco.Cms.Integrations.Commerce.Shopify.Configuration;
 
 #if NETCOREAPP
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Models.PublishedContent;
 #else
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
+using System.Configuration;
 #endif
 
 namespace Umbraco.Cms.Integrations.Commerce.Shopify.Editors
@@ -18,9 +21,19 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Editors
     public class ShopifyProductPickerValueConverter : PropertyValueConverterBase
     {
         private readonly IShopifyService _apiService;
+        private readonly ShopifySettings _settings;
 
+#if NETCOREAPP
+        public ShopifyProductPickerValueConverter(IOptions<ShopifySettings> options, IShopifyService apiService)
+#else
         public ShopifyProductPickerValueConverter(IShopifyService apiService)
+#endif
         {
+#if NETCOREAPP
+            _settings = options.Value;
+#else
+            _settings = new ShopifySettings(ConfigurationManager.AppSettings);
+#endif
             _apiService = apiService;
         }
 
@@ -30,7 +43,7 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Editors
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType) => typeof(List<ProductViewModel>);
 
         public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) =>
-            PropertyCacheLevel.Snapshot;
+            _settings.CacheLevel;
 
         public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source,
             bool preview)

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
@@ -43,7 +43,7 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Editors
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType) => typeof(List<ProductViewModel>);
 
         public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) =>
-            _settings.CacheLevel;
+            _settings.PropertyCacheLevel;
 
         public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source,
             bool preview)

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Umbraco.Cms.Integrations.Commerce.Shopify.csproj
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Umbraco.Cms.Integrations.Commerce.Shopify.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net472;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -16,6 +16,46 @@
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
 		<PackageIcon>shopify.png</PackageIcon>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net472|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net5.0|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net472|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net5.0|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net7.0|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Umbraco.Cms.Integrations.Commerce.Shopify.csproj
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Umbraco.Cms.Integrations.Commerce.Shopify.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net472;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -16,46 +16,6 @@
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
 		<PackageIcon>shopify.png</PackageIcon>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net472|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net5.0|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net472|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net5.0|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net7.0|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net472'">
@@ -76,12 +36,12 @@
 		<PackageReference Include="Umbraco.Cms.Web.Website" version="[11.0.0,13)" />
 		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[11.0.0,13)" />
 	</ItemGroup>
-	
+
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="Umbraco.Cms.Web.Website" version="[13.0.0,14)" />
 		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[13.0.0,14)" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<Content Include="App_Plugins\UmbracoCms.Integrations\Commerce\Shopify\**\*.*">
 			<Pack>true</Pack>


### PR DESCRIPTION
On `ShopifyProductPickerValueConverter` with `GetPropertyCacheLevel` set to return `PropertyCacheLevel.Snapshot` the site can hit rate limits on the Shopify Admin API. More information on rate limits is found here https://shopify.dev/docs/api/usage/rate-limits.

It also creates unnecessary round trips to the Shopify Admin API as the products are not being changed on a per request level, but when the content editor updates the page the products are being displayed on.

As such this PR allows the developer to override the default cache level by using a configuration setting`PropertyCacheLevel` eg 

```
"CMS": {
		"Integrations": {
			"Commerce": {
				"Shopify": {
					"Settings": {
						"ApiVersion": "2024-04",
						"Shop": "MYSHOP",
						"AccessToken": "MYACCESSTOKEN",
						"PropertyCacheLevel": "Element"
					}
				}
			}
		}
```

The cache levels are defined here https://docs.umbraco.com/umbraco-cms/10.latest/extending/property-editors/property-value-converters

Please let me know when this has been approved and I will update the Umbraco Docs to reflect this change