### PR TITLE
Update Shopify property editor cache level

### DIFF
--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Configuration/ShopifySettings.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Configuration/ShopifySettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Umbraco.Cms.Integrations.Commerce.Shopify.Configuration
+﻿using Umbraco.Cms.Core.PropertyEditors;
+
+namespace Umbraco.Cms.Integrations.Commerce.Shopify.Configuration
 {
     public class ShopifySettings
     {
@@ -9,5 +11,7 @@
         public string AccessToken { get; set; } = string.Empty;
 
         public bool UseUmbracoAuthorization { get; set; } = true;
+
+        public PropertyCacheLevel PropertyCacheLevel { get; set; } = PropertyCacheLevel.Snapshot;
     }
 }

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerValueConverter.cs
@@ -1,6 +1,7 @@
-﻿using System.Text.Json;
+﻿using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Integrations.Commerce.Shopify.Configuration;
 using Umbraco.Cms.Integrations.Commerce.Shopify.Models.ViewModels;
 using Umbraco.Cms.Integrations.Commerce.Shopify.Services;
 
@@ -8,10 +9,12 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Editors
 {
     public class ShopifyProductPickerValueConverter : PropertyValueConverterBase
     {
+        private readonly ShopifySettings _settings;
         private readonly IShopifyService _apiService;
 
-        public ShopifyProductPickerValueConverter(IShopifyService apiService)
+        public ShopifyProductPickerValueConverter(IOptions<ShopifySettings> options, IShopifyService apiService)
         {
+            _settings = options.Value;
             _apiService = apiService;
         }
 
@@ -21,7 +24,7 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify.Editors
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType) => typeof(List<ProductViewModel>);
 
         public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) =>
-            PropertyCacheLevel.Snapshot;
+            _settings.PropertyCacheLevel;
 
         public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source,
             bool preview)

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Umbraco.Cms.Integrations.Commerce.Shopify.csproj
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Umbraco.Cms.Integrations.Commerce.Shopify.csproj
@@ -16,7 +16,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main-v14/src/Umbraco.Cms.Integrations.Commerce.Shopify</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>3.0.0</Version>
+		<Version>3.1.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageIcon>shopify.png</PackageIcon>


### PR DESCRIPTION
Current PR aligns the changes from #240 with V15 of the integration.