### PR TITLE
Match BuildIndex logic with ContentRefresher

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Controllers/SearchController.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Controllers/SearchController.cs
@@ -139,7 +139,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Controllers
 
                     _logger.LogInformation("Building index for {ContentType} with {Count} items", contentDataItem.ContentType.Alias, contentItems.Count());
 
-                    foreach (var contentItem in contentItems.Where(p => !p.Trashed))
+                    foreach (var contentItem in contentItems.Where(p => !p.Trashed && p.Published))
                     {
                         var record = new ContentRecordBuilder(
                                 _userService, 


### PR DESCRIPTION
Added p.Published check in the BuildIndex loop so it skips unpublished items too — same as ContentRefresher already does.