### PR TITLE
Bugfix/v13/hubspot refresh token attempt

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Controllers/FormsController.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Controllers/FormsController.cs
@@ -77,7 +77,7 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Core.Controllers
             try
             {
                 var requestMessage = CreateRequest(hubspotApiKey);
-
+                
                 var response = await ClientFactory().SendAsync(requestMessage);
 
                 responseContent = await response.Content.ReadAsStringAsync();
@@ -240,7 +240,7 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Core.Controllers
             {
                 // Attempt to refresh the access token
                 var refreshAccessTokenResponse = await _authorizationService.RefreshAccessTokenAsync();
-                if (string.IsNullOrEmpty(refreshAccessTokenResponse) || refreshAccessTokenResponse == "error")
+                if (string.IsNullOrEmpty(refreshAccessTokenResponse) || refreshAccessTokenResponse == BaseAuthorizationService.ErrorPrefix)
                 {
                     return new ResponseDto
                     {

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Controllers/FormsController.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Controllers/FormsController.cs
@@ -240,7 +240,7 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Core.Controllers
             {
                 // Attempt to refresh the access token
                 var refreshAccessTokenResponse = await _authorizationService.RefreshAccessTokenAsync();
-                if (string.IsNullOrEmpty(refreshAccessTokenResponse) || refreshAccessTokenResponse == BaseAuthorizationService.ErrorPrefix)
+                if (string.IsNullOrEmpty(refreshAccessTokenResponse) || refreshAccessTokenResponse.StartsWith(BaseAuthorizationService.ErrorPrefix))
                 {
                     return new ResponseDto
                     {

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Services/AuthorizationService.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Services/AuthorizationService.cs
@@ -68,10 +68,10 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Core.Services
                 var errorResult = await response.Content.ReadAsStringAsync();
                 var errorDto = JsonConvert.DeserializeObject<ErrorDto>(errorResult);
 
-                return "Error: " + errorDto.Message;
+                return string.Format("{0}: {1}", ErrorPrefix, errorDto.Message);
             }
 
-            return "Error: An unexpected error occurred.";
+            return string.Format("{0}: An unexpected error occurred.", ErrorPrefix);
         }
 
         public string RefreshAccessToken() =>
@@ -83,9 +83,9 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Core.Services
 
             var data = new Dictionary<string, string>
             {
-                {"grant_type", "refresh_token"},
-                {"client_id", _oauthSettings.ClientId },
-                {"client_secret", _oauthSettings.ClientSecret },
+                { "grant_type", "refresh_token" },
+                { "client_id", _oauthSettings.ClientId },
+                { "client_secret", _oauthSettings.ClientSecret },
                 { "refresh_token", refreshToken }
             };
 
@@ -109,7 +109,7 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Core.Services
                 return result;
             }
 
-            return "error";
+            return ErrorPrefix;
         }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Services/BaseAuthorizationService.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Services/BaseAuthorizationService.cs
@@ -18,6 +18,8 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Core.Services
 
         protected readonly ITokenService TokenService;
 
+        public const string ErrorPrefix = "Error";
+
         public BaseAuthorizationService(ITokenService tokenService)
         {
             TokenService = tokenService;

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Services/UmbracoAuthorizationService.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Services/UmbracoAuthorizationService.cs
@@ -75,10 +75,10 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Core.Services
                 var errorResult = await response.Content.ReadAsStringAsync();
                 var errorDto = JsonConvert.DeserializeObject<ErrorDto>(errorResult);
 
-                return "Error: " + errorDto.Message;
+                return string.Format("{0}: {1}", ErrorPrefix, errorDto.Message);
             }
 
-            return "Error: An unexpected error occurred.";
+            return string.Format("{0}: An unexpected error occurred.", ErrorPrefix);
         }
 
         public string RefreshAccessToken() =>
@@ -90,8 +90,8 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Core.Services
 
             var data = new Dictionary<string, string>
             {
-                {"grant_type", "refresh_token"},
-                {"client_id", ClientId },
+                { "grant_type", "refresh_token" },
+                { "client_id", ClientId },
                 { "refresh_token", refreshToken }
             };
 
@@ -116,7 +116,7 @@ namespace Umbraco.Cms.Integrations.Crm.Hubspot.Core.Services
                 return result;
             }
 
-            return "error";
+            return ErrorPrefix;
         }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Umbraco.Cms.Integrations.Crm.Hubspot.Core.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot.Core/Umbraco.Cms.Integrations.Crm.Hubspot.Core.csproj
@@ -11,7 +11,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Crm.Hubspot</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>4.0.2</Version>
+		<Version>4.0.3</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 	</PropertyGroup>

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Umbraco.Cms.Integrations.Crm.Hubspot.csproj
@@ -10,7 +10,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Crm.Hubspot</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>4.0.3</Version>
+		<Version>4.0.4</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR addresses the issue detailed in #270 and adds an attempt to refresh the access token in the stages of token validation.