### PR TITLE
Fix compositions for content types and version update

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Api/Management/Controllers/GetContentTypesController.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Api/Management/Controllers/GetContentTypesController.cs
@@ -55,7 +55,7 @@ public class GetContentTypesController : SearchControllerBase
         foreach (var contentType in contentTypes)
         {
             var properties = new List<ContentTypePropertyDto>();
-            foreach (var propertyGroup in contentType.PropertyGroups)
+            foreach (var propertyGroup in contentType.CompositionPropertyGroups)
             {
                 if (propertyGroup.PropertyTypes is null)
                 {

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Client/src/dashboard/search-management-dashboard/views/algolia-dashboard-overview.ts
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Client/src/dashboard/search-management-dashboard/views/algolia-dashboard-overview.ts
@@ -121,6 +121,7 @@ export class AlgoliaDashboardOverviewElement extends UmbElementMixin(LitElement)
                   <uui-table-cell>${index.name}</uui-table-cell>
                   <uui-table-cell>
                         ${index.contentData.map((contentData) => {
+                            if (!contentData.properties) return;
                             return html`
                                 <uui-ref-node name=${contentData.name}
                                             detail=${contentData.properties.map(obj => obj.name).join(', ')}>

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Search.Algolia</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>4.0.0</Version>
+		<Version>4.0.1</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR addresses issue #254 and handles the following two use cases:

* Composition properties are not being displayed when working with indices in the backoffice
* In an upgrade scenario (from 13 to 15/16 and up) the JSON payload has a different structure, causing the `properties` array to be `NULL`. In consequence, the list of indices does not load properly.