### PR TITLE
Trigger memory cache reload on load balanced published

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/AlgoliaComposer.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/AlgoliaComposer.cs
@@ -23,8 +23,9 @@ namespace Umbraco.Cms.Integrations.Crm.ActiveCampaign
             builder.AddNotificationHandler<UmbracoApplicationStartingNotification, RunAlgoliaIndicesMigration>();
 
             builder.AddNotificationAsyncHandler<ContentCacheRefresherNotification, AlgoliaContentCacheRefresherHandler>();
-            
-           builder.Services.AddOptions<AlgoliaSettings>()
+            builder.AddNotificationAsyncHandler<ContentPublishedNotification, AlgoliaContentPublishedHandler>();
+
+            builder.Services.AddOptions<AlgoliaSettings>()
                 .Bind(builder.Config.GetSection(Constants.SettingsPath));
 
             builder.Services.AddSingleton<IAlgoliaIndexService, AlgoliaIndexService>();

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/package.manifest
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/package.manifest
@@ -1,6 +1,6 @@
 ﻿{
 	"name": "Umbraco.Cms.Integrations.Search.Algolia",
-	"version": "1.3.1",
+	"version": "2.3.3",
 	"allowPackageTelemetry": true,
 	"javascript": [
 		"~/App_Plugins/UmbracoCms.Integrations/Search/Algolia/js/algolia.service.js",

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentPublishedHandler.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentPublishedHandler.cs
@@ -2,8 +2,6 @@
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Sync;
-using Umbraco.Extensions;
-
 namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
 {
     public class AlgoliaContentPublishedHandler : INotificationAsyncHandler<ContentPublishedNotification>

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentPublishedHandler.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentPublishedHandler.cs
@@ -1,0 +1,31 @@
+﻿using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
+{
+    public class AlgoliaContentPublishedHandler : INotificationAsyncHandler<ContentPublishedNotification>
+    {
+        private readonly IServerRoleAccessor _serverRoleAccessor;
+        private readonly DistributedCache _distributedCache;
+
+        public AlgoliaContentPublishedHandler(
+            IServerRoleAccessor serverRoleAccessor,
+            DistributedCache distributedCache)
+        {
+            _serverRoleAccessor = serverRoleAccessor;
+            _distributedCache = distributedCache;
+        }
+
+        public async Task HandleAsync(ContentPublishedNotification notification, CancellationToken cancellationToken)
+        {
+            if (_serverRoleAccessor.CurrentServerRole == ServerRole.SchedulingPublisher)
+            {
+                _distributedCache.RefreshAllPublishedSnapshot();
+            }
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentPublishedHandler.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentPublishedHandler.cs
@@ -2,6 +2,8 @@
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Sync;
+using Umbraco.Extensions;
+
 namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
 {
     public class AlgoliaContentPublishedHandler : INotificationAsyncHandler<ContentPublishedNotification>
@@ -21,7 +23,7 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
         {
             if (_serverRoleAccessor.CurrentServerRole == ServerRole.SchedulingPublisher)
             {
-                _distributedCache.RefreshAllPublishedSnapshot();
+                _distributedCache.RefreshAllContentCache();
             }
             return Task.CompletedTask;
         }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentPublishedHandler.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentPublishedHandler.cs
@@ -19,13 +19,13 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
             _distributedCache = distributedCache;
         }
 
-        public async Task HandleAsync(ContentPublishedNotification notification, CancellationToken cancellationToken)
+        public Task HandleAsync(ContentPublishedNotification notification, CancellationToken cancellationToken)
         {
             if (_serverRoleAccessor.CurrentServerRole == ServerRole.SchedulingPublisher)
             {
                 _distributedCache.RefreshAllPublishedSnapshot();
             }
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Search.Algolia</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>2.3.2</Version>
+		<Version>2.3.3</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR attempts to fix issue [#13](https://github.com/umbraco/Umbraco.Integrations.Issues/issues/13) by forcing a memory cache reload when working in a load balanced environment through a `ContentPublishedNotification` handler.