### PR TITLE
Bugfix/v13/algolia changed nodes refresh content cache

### DIFF
--- a/azure-pipeline - Search.Algolia.yml
+++ b/azure-pipeline - Search.Algolia.yml
@@ -59,7 +59,7 @@ steps:
     mkdir -p $(Build.ArtifactStagingDirectory)/bom
     cd $(Build.SourcesDirectory)
 
-    cdxgen --recurse --output $(Build.ArtifactStagingDirectory)\bom\bom.json --json-pretty --project-group "$(productGroup)" --project-name "$(projectName)" --project-version "$(productVersion)" --server-url "$(DT_BASE_URL)" --api-key "$(DT_API_KEY)" --deep
+    cdxgen --recurse --output $(Build.ArtifactStagingDirectory)\bom\bom.json --json-pretty --project-group "$(productGroup)" --project-name "$(projectName)" --project-version "$(productVersion)" --server-url "$(DT_BASE_URL)" --api-key "$(DT_API_KEY)" --deep --spec-version 1.6
   displayName: 'Generate & Upload SBOM with cdxgen'
   env:
     DT_API_KEY: $(DT_API_KEY)

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/package.manifest
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/package.manifest
@@ -1,6 +1,6 @@
 ﻿{
 	"name": "Umbraco.Cms.Integrations.Search.Algolia",
-	"version": "2.3.3",
+	"version": "2.4.0-rc1",
 	"allowPackageTelemetry": true,
 	"javascript": [
 		"~/App_Plugins/UmbracoCms.Integrations/Search/Algolia/js/algolia.service.js",

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/package.manifest
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/App_Plugins/UmbracoCms.Integrations/Search/Algolia/package.manifest
@@ -1,6 +1,6 @@
 ﻿{
 	"name": "Umbraco.Cms.Integrations.Search.Algolia",
-	"version": "2.4.0-rc1",
+	"version": "2.4.0",
 	"allowPackageTelemetry": true,
 	"javascript": [
 		"~/App_Plugins/UmbracoCms.Integrations/Search/Algolia/js/algolia.service.js",

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentPublishedHandler.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentPublishedHandler.cs
@@ -1,6 +1,8 @@
 ﻿using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services.Changes;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Extensions;
 
@@ -21,10 +23,20 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
 
         public Task HandleAsync(ContentPublishedNotification notification, CancellationToken cancellationToken)
         {
-            if (_serverRoleAccessor.CurrentServerRole == ServerRole.SchedulingPublisher)
+            if (_serverRoleAccessor.CurrentServerRole != ServerRole.SchedulingPublisher)
             {
-                _distributedCache.RefreshAllContentCache();
+                return Task.CompletedTask;
             }
+
+            var changes = notification.PublishedEntities
+                .Select(entity => new TreeChange<IContent>(entity, TreeChangeTypes.RefreshNode));
+
+#if NET8_0_OR_GREATER
+            _distributedCache.RefreshContentCache(changes);
+#else
+            _distributedCache.RefreshContentCache(changes.ToArray());
+#endif
+
             return Task.CompletedTask;
         }
     }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Search.Algolia</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>2.4.0-rc1</Version>
+		<Version>2.4.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Umbraco.Cms.Integrations.Search.Algolia.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Cms.Integrations/tree/main/src/Umbraco.Cms.Integrations.Search.Algolia</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Cms.Integrations</RepositoryUrl>
-		<Version>2.3.3</Version>
+		<Version>2.4.0-rc1</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR fixes issue [#22](https://github.com/umbraco/Umbraco.Integrations.Issues/issues/22) that caused `OutOfMemoryException` for content heavy instances. 

To fix this,  I've updated the `AlgoliaContentPublishedHandler` to refresh the cache for content nodes that have been changed, instead of the whole cache.