### PR TITLE
Skip a removed version.json in changelog validation

### DIFF
--- a/.azure-pipelines/scripts/validate-changelogs.ps1
+++ b/.azure-pipelines/scripts/validate-changelogs.ps1
@@ -94,7 +94,18 @@ foreach ($versionFile in $changedVersionFiles) {
     $packageDir = Split-Path $versionFile -Parent
     $packageName = Split-Path $packageDir -Leaf
 
-    $version = Get-VersionFromJson -Path (Join-Path $RootPath $versionFile)
+    # git diff reports deletions too. A removed version.json means the package is
+    # leaving the line (or has not joined it yet) - there is no version to
+    # document, so there is nothing to validate. Without this the file shows up as
+    # "changed", the read returns nothing, and the build fails on a package that
+    # is deliberately absent.
+    $versionPath = Join-Path $RootPath $versionFile
+    if (-not (Test-Path $versionPath)) {
+        Write-Host "  skip $packageName (version.json removed)" -ForegroundColor DarkGray
+        continue
+    }
+
+    $version = Get-VersionFromJson -Path $versionPath
     if (-not $version) {
         $problems += "$packageName : version.json has no 'version' value"
         continue


### PR DESCRIPTION
`validate-changelogs.ps1` takes its list of packages from `git diff`, which reports **deletions** as well as edits. A removed `version.json` was then read for a version that is not there, failing the build with `version.json has no 'version' value` on a package that is deliberately absent.

Found while resolving conflicts on #317, the seed branch for `main-v18`. That branch removes `Analytics.Cookiebot/version.json` on purpose — Cookiebot 4.0.0 has never been published, so seeding it would record it as already released and it would never ship. #317 could not have gone green without this fix.

A removed `version.json` means the package is leaving the line, or has not joined it yet. There is no version to document, so it is now skipped and logged.

`detect-changes.ps1` already handled this correctly: no `version.json` means the folder is not a package, so Cookiebot is simply not discovered.

The same fix is already on #317, #318 and #319. This PR is only so `v18/dev` has it too, since #316 merged before it was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)