### PR TITLE
Count release events repo-wide, not per line

### DIFF
--- a/.claude/skills/release-management/SKILL.md
+++ b/.claude/skills/release-management/SKILL.md
@@ -177,22 +177,36 @@ arrangement `Umbraco.AI` and `Umbraco.Automate` use.
 It is independent of the package versions: one release branch can carry several
 packages at different versions.
 
+**`N` counts release events across the whole repo, not per line.** It comes from
+the date tags, which have no line prefix, so a v17 release and a v18 release share
+one sequence. `Umbraco.Automate` and `Umbraco.AI` both work this way - Automate
+currently has `v18/release/2026.08.1` alongside `v17/release/2026.08.2`, because
+the v18 release took `.1` and the v17 one that followed took `.2`.
+
+Do **not** derive `N` from branch names. That gives both lines a `.1` in the same
+month, and the collision only shows up later when the date tags are created.
+
 Work out the name:
 
 ```bash
 git branch --show-current            # the line prefix, e.g. v18/dev -> v18
 date +%Y.%m                          # e.g. 2026.08
+
 git fetch origin --tags
-git branch -r --list "origin/v18/release/*"      # existing branches this month
-git tag --list "2026.08.*"                       # and any date tags
+git tag --list "2026.08.*" | sort -V | tail -1   # highest release event this month
 ```
 
-Take the highest trailing number for the current month and add one; start at `1` if
-there is none. Confirm the name with the user, then:
+`git tag --list "2026.08.*"` matches only date tags, never the
+`release/<slug>-<version>` package tags. Take the highest trailing number and add
+one; start at `1` if the month has none. Confirm the name with the user, then:
 
 ```bash
 git checkout -b v18/release/2026.08.1
 ```
+
+The matching date tag `2026.08.1` is created at release time, in Phase 9, next to
+the per-package tags. It is what lets the next release pick the right number, so
+skipping it breaks the sequence for whoever releases next - on either line.
 
 For an urgent fix on top of an already-released state, cut
 `v18/hotfix/YYYY.MM.N` from `main-v18` instead of from dev.
@@ -338,11 +352,22 @@ Still to do by hand:
   3. Tag each released package, on the release branch:
        git tag -a release/search-algolia-7.1.0 -m "Search.Algolia 7.1.0"
        git tag -a release/crm-hubspot-9.0.2    -m "Crm.Hubspot 9.0.2"
+  4. Tag the release event itself, on the same branch:
+       git tag -a 2026.08.1 -m "Release 2026.08.1"
+     This one is repo-wide and carries no line prefix. It is how the NEXT
+     release works out its number, on either line - skip it and the sequence
+     breaks.
        git push origin --tags
-  4. Create a GitHub release per tag, titled with the tag, linking the PRs.
-  5. Run /post-release-cleanup to merge the release branch into main-v18
+  5. Create a GitHub release per PACKAGE tag, titled with the tag, linking the
+     PRs. The date tag is bookkeeping and gets no GitHub release.
+  6. Run /post-release-cleanup to merge the release branch into main-v18
      and v18/dev, and bump the dev patch versions.
 ```
+
+> The two tag shapes answer different questions. `release/<slug>-<version>` is
+> "which commit is this published package", one per package. `YYYY.MM.N` is "which
+> commits went out together", one per release branch. They share the tag namespace
+> but cannot collide: one starts with `release/`, the other with a digit.
 
 Do not promote, tag, or create GitHub releases yourself unless the user explicitly
 asks - those are outward-facing and irreversible.

--- a/.gitignore
+++ b/.gitignore
@@ -491,6 +491,11 @@ $RECYCLE.BIN/
 # IDE project cache can still write it. Never commit it.
 **/config.outputPath.js
 
+# There is ONE lockfile for all clients, at the repo root - the Client folders are
+# npm workspaces of it. Per-client lockfiles were deleted in the build redesign and
+# must not come back; stale ones on disk get re-added by `git add -A` otherwise.
+src/*/Client/package-lock.json
+
 # Compiled backoffice client assets. Built from src/<package>/Client by the root
 # npm workspace (`npm ci && npm run build`) and by CI before pack - never committed.
 # Committing them meant every dependency resolution churned the Vite chunk hashes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,9 @@ The pipeline **only builds + packs the `.nupkg` + SBOM as artifacts** — it doe
 >
 > This is a real behavioural difference from the old manual process, where the csproj `<Version>` was clean on every branch and any build was publishable.
 
-**Release branches:** `v<N>/release/YYYY.MM.N` (calendar-based, cut from `v<N>/dev`), and `v<N>/hotfix/YYYY.MM.N` for an urgent fix cut from `main-v<N>`. The name is independent of package versions — one branch can carry several packages at different versions. Note the branch (`v18/release/2026.08.1`) and the tags (`release/<slug>-<version>`) are different ref namespaces and do not collide.
+**Release branches:** `v<N>/release/YYYY.MM.N` (calendar-based, cut from `v<N>/dev`), and `v<N>/hotfix/YYYY.MM.N` for an urgent fix cut from `main-v<N>`. The name is independent of package versions — one branch can carry several packages at different versions.
+
+> **`N` counts release events across the whole repo, not per line.** It is derived from the `YYYY.MM.N` date tags, which carry no line prefix, so v17 and v18 releases share one sequence — `v18/release/2026.08.1` is followed by `v17/release/2026.08.2`, not a second `.1`. This matches `Umbraco.Automate` and `Umbraco.AI`, which both derive it from those tags. Two tag shapes are in play and cannot collide: `release/<slug>-<version>` identifies a published package, `YYYY.MM.N` identifies the release event and is what the next release counts from.
 
 **No release manifest.** Unlike `Umbraco.AI`, there is no `release-manifest.json`. On a release branch, CI treats a package as shipping when its `version.json` differs from `main-v<N>` — the bump itself is the declaration.
 


### PR DESCRIPTION
The release number `N` in `v<N>/release/YYYY.MM.N` was being derived from existing release **branch** names, scoped to the line. That produced `v18/release/2026.08.1` and `v17/release/2026.08.1` in the same month — two separate release events both claiming `.1`.

## How the siblings actually do it

`Umbraco.Automate` and `Umbraco.AI` both derive `N` from the `YYYY.MM.N` **date tags**, not from branch names. Those tags carry no line prefix, so the sequence is shared across lines.

Evidence:

- Automate currently has `v18/release/2026.08.1` alongside `v17/release/2026.08.2` — the v18 release took `.1`, the v17 one that followed took `.2`.
- Automate's date tags run `2026.06.1` … `2026.07.4`, spanning both its lines. Umbraco.AI has 30 such tags.
- Both skills say `git tag --list "YYYY.MM.*"` and increment the highest.

**This repo was missing that mechanism entirely.** It creates no date tags at all, which is why nothing flagged the duplicate.

## Changes

- Derive `N` from `git tag --list "YYYY.MM.*"`, and say explicitly not to use branch names.
- Create the date tag as part of the release, in Phase 9, next to the per-package tags — it is what the next release counts from, on either line.
- Document the two tag shapes and why they cannot collide: `release/<slug>-<version>` identifies a published package, `YYYY.MM.N` identifies the release event. One starts with `release/`, the other with a digit.
- Same note added to `CLAUDE.md`.

Also adds a `.gitignore` rule for `src/*/Client/package-lock.json`. Those files were deleted by the build redesign in favour of one root lockfile, but stale copies linger on disk and get re-added by `git add -A` — which happened to me while making this change.

## Note

The v17 release branch cut today was renamed from `2026.08.1` to `2026.08.2` to match. Both release branches have since been deleted so bugfixes can go in first, so nothing depends on this beyond getting the next cut right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)