### PR TITLE
fix(algolia): remove descendants from the index on a branch delete

### DIFF
--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentCacheRefresherHandler.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Handlers/AlgoliaContentCacheRefresherHandler.cs
@@ -15,6 +15,7 @@ using Umbraco.Cms.Integrations.Search.Algolia.Models;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Integrations.Search.Algolia.Models.ContentTypeDtos;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
 {
@@ -89,13 +90,49 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Handlers
                     break;
             }
 
-            var refreshedContent = _contentService
-                .GetByIds(
-                    payloads
-                        .Where(p => p.ChangeTypes == TreeChangeTypes.RefreshNode || p.ChangeTypes == TreeChangeTypes.RefreshBranch)
-                        .Select(p => p.Id));
+            var refreshedContent = new List<IContent>();
+
+            foreach (var payload in payloads)
+            {
+                var isBranchChange = payload.ChangeTypes.HasType(TreeChangeTypes.RefreshBranch);
+
+                if (!isBranchChange && !payload.ChangeTypes.HasType(TreeChangeTypes.RefreshNode)) continue;
+
+                var content = _contentService.GetById(payload.Id);
+                if (content == null) continue;
+
+                refreshedContent.Add(content);
+
+                // A branch change - moving a node to the recycle bin, for example - only sends a payload for the
+                // branch root, so its descendants have to be collected here or they are left stale in the index.
+                if (isBranchChange)
+                {
+                    refreshedContent.AddRange(GetDescendants(content));
+                }
+            }
 
             await RebuildIndex(refreshedContent);
+        }
+
+        private IEnumerable<IContent> GetDescendants(IContent content)
+        {
+            const int pageSize = 500;
+
+            var pageIndex = 0;
+            long total;
+
+            do
+            {
+                var page = _contentService.GetPagedDescendants(content.Id, pageIndex, pageSize, out total);
+
+                foreach (var descendant in page)
+                {
+                    yield return descendant;
+                }
+
+                pageIndex++;
+            }
+            while (pageIndex * pageSize < total);
         }
 
         protected async Task RebuildIndex(IEnumerable<IContent> entities)


### PR DESCRIPTION
Fixes umbraco/Umbraco.Integrations.Issues#33

## The bug

Deleting a content node removed it from the Algolia index. Deleting its **parent** left every descendant in the index indefinitely.

## Root cause

`AlgoliaContentCacheRefresherHandler.HandleAsync` looked up only the ids present in the notification payload. Umbraco sends a single `RefreshBranch` payload for the branch root, so descendants were never fetched and never reindexed.

The same lines also compared a `[Flags]` enum with `==`:

```csharp
.Where(p => p.ChangeTypes == TreeChangeTypes.RefreshNode || p.ChangeTypes == TreeChangeTypes.RefreshBranch)
```

which silently misses any payload carrying a combination of flags.

## The fix

- On a `RefreshBranch`, walk the branch root's descendants via `GetPagedDescendants` in pages of 500 and reindex them alongside it.
- Use `HasType` instead of equality.

`RebuildIndex` already deletes anything trashed or unpublished, so a trashed descendant now leaves the index on the same pass.

## Validation

Not validated at runtime — that needs an Algolia app ID and admin key, which I did not have. The change compiles and the reasoning is from the payload shape Umbraco emits. **Worth a manual check against a real index before release.**

## Notes

No version bump or changelog entry — that is release work.
