### PR TITLE
chore: make the V18 test site installable unattended

### DIFF
--- a/Umbraco.Cms.Integrations.slnx
+++ b/Umbraco.Cms.Integrations.slnx
@@ -53,5 +53,5 @@
   <Folder Name="/Tests/">
     <Project Path="tests/Umbraco.Cms.Integrations.Crm.Hubspot.Tests/Umbraco.Cms.Integrations.Crm.Hubspot.Tests.csproj" />
   </Folder>
-  <Project Path="examples/Umbraco.Cms.Integrations.Testsite.V18/Umbraco.Cms.Integrations.Testsite.V18.csproj" />
+  <Project Path="examples/Umbraco.Cms.Integrations.Testsite.V18/Umbraco.Cms.Integrations.Testsite.V18.csproj" DisplayName="Umbraco.Cms.Integrations.TestSite.V18" />
 </Solution>

--- a/examples/Umbraco.Cms.Integrations.Testsite.V18/appsettings.Development.json
+++ b/examples/Umbraco.Cms.Integrations.Testsite.V18/appsettings.Development.json
@@ -30,6 +30,13 @@
       },
       "Hosting": {
         "Debug": true
+      },
+      "Unattended": {
+        "InstallUnattended": true,
+        "UpgradeUnattended": true,
+        "UnattendedUserName": "Admin",
+        "UnattendedUserEmail": "admin@example.com",
+        "UnattendedUserPassword": "1234567890"
       }
     }
   }


### PR DESCRIPTION
Housekeeping split out of the bug-fix PRs so those stay reviewable.

## Changes

- **Unattended install settings** for the test site's `appsettings.Development.json`. A fresh clone currently boots to the installer; with this it comes up as a usable backoffice, which is what makes automated browser testing against the test site practical.
- **Display name** for the test site project in the solution file (v18 only — the v17 line has a `.sln`, which has no equivalent attribute).

## Please read before merging

The unattended block contains credentials:

```json
"UnattendedUserEmail": "admin@example.com",
"UnattendedUserPassword": "1234567890"
```

These are throwaway local values for a SQLite database that is not in source control, so they are not a shared secret. They are still credentials in a committed file. Swap them, move them to user secrets, or drop this PR if that is not wanted — the bug-fix PRs do not depend on it.
