### PR TITLE
fix(hubspot): show the correct form picker configuration description

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Client/src/property-editor/authorization-property-editor.element.ts
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Client/src/property-editor/authorization-property-editor.element.ts
@@ -73,11 +73,13 @@ export class HubspotAuthorizationElement extends UmbElementMixin(LitElement) {
 
         if (!this.#settingsModel) return;
 
+        const type = this.#settingsModel.type?.value ?? "";
+
         this._serviceStatus = {
             isValid: this.#settingsModel.isValid,
-            type: this.#settingsModel.type?.value!,
-            description: this.#getDescription(this._serviceStatus.type),
-            useOAuth: this.#settingsModel.isValid && this.#settingsModel.type?.value === "OAuth"
+            type: type,
+            description: this.#getDescription(type),
+            useOAuth: this.#settingsModel.isValid && type === "OAuth"
         }
 
         if (this._serviceStatus.useOAuth) {
@@ -108,11 +110,13 @@ export class HubspotAuthorizationElement extends UmbElementMixin(LitElement) {
         }
     }
 
+    // The server sends the configuration type as "API" / "OAuth" (see ConfigurationType.cs),
+    // so match case-insensitively.
     #getDescription(type: string): string {
-        switch (type) {
+        switch (type?.toLowerCase()) {
             case "api": return ConfigDescription.api;
             case "oauth": return ConfigDescription.oauth;
-            case "oauthConnected": return ConfigDescription.oauthConnected;
+            case "oauthconnected": return ConfigDescription.oauthConnected;
             default: return ConfigDescription.none;
         }
     }


### PR DESCRIPTION
> Backport of #324 to the v17 line.

Fixes umbraco/Umbraco.Integrations.Issues#31

## The bug

The HubSpot form picker always reported **"No API or OAuth configuration could be found. Please review your settings before continuing."**, even on a correctly configured site. The reporter could see their forms listed directly above the message.

## Root cause

Two defects in `authorization-property-editor.element.ts`, both on the same line:

1. `#checkApiConfiguration` built the new service status object, but passed the **previous** `this._serviceStatus.type` into `#getDescription`. On the first run that is the initial `""`.
2. `#getDescription` matched `"api"` and `"oauth"`, but the server sends `"API"` and `"OAuth"` (`Models/ConfigurationType.cs`). So even with the right value the switch fell through to `default`.

Either alone was enough to always return `ConfigDescription.none`.

## Validation

Red/green against a real Umbraco 18 backoffice, driving the browser with Playwright:

| | description shown |
|---|---|
| before | `No API or OAuth configuration could be found. Please review your settings before continuing.` |
| after | `No API key is configured. To connect to your HubSpot account using OAuth click 'Connect', select your account and agree to the permissions.` |

Same page, same server state, `serviceStatus.type` was `OAuth` in both runs. The only difference was this patch.

## Notes

No version bump or changelog entry — that is release work.
