### PR TITLE
fix(shopify): store product picker values as JSON

### DIFF
--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerPropertyEditor.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Editors/ShopifyProductPickerPropertyEditor.cs
@@ -2,8 +2,12 @@
 
 namespace Umbraco.Cms.Integrations.Commerce.Shopify.Editors
 {
+    // ValueType must be JSON: the editor posts an array of product ids, and without it the default
+    // string storage type calls ToString() on the collection, writing "System.Collections.Generic.List`1[System.Int64]"
+    // into the database instead of the ids.
     [DataEditor(
-        "Umbraco.Cms.Integrations.Commerce.Shopify.ProductPicker",
+        Constants.PropertyEditors.ProductPickerAlias,
+        ValueType = ValueTypes.Json,
         ValueEditorIsReusable = true)]
     public class ShopifyProductPickerPropertyEditor : DataEditor
     {

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Migrations/MigrateProductPickerToJsonStorage.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Migrations/MigrateProductPickerToJsonStorage.cs
@@ -1,0 +1,106 @@
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
+
+namespace Umbraco.Cms.Integrations.Commerce.Shopify.Migrations
+{
+    /// <summary>
+    /// Moves the Shopify product picker from string to JSON storage.
+    /// </summary>
+    /// <remarks>
+    /// The property editor previously used the default string value type, which stores its value in
+    /// <c>varcharValue</c>. It now declares <see cref="ValueTypes.Json"/>, so existing data types need their
+    /// <see cref="IDataType.DatabaseType"/> corrected and their property data relocated to <c>textValue</c>,
+    /// or previously saved selections would read back as null.
+    /// </remarks>
+    public class MigrateProductPickerToJsonStorage : AsyncMigrationBase
+    {
+        private readonly IDataTypeService _dataTypeService;
+
+        public MigrateProductPickerToJsonStorage(IMigrationContext context, IDataTypeService dataTypeService)
+            : base(context) => _dataTypeService = dataTypeService;
+
+        protected override async Task MigrateAsync()
+        {
+            var dataTypes = await _dataTypeService.GetByEditorAliasAsync(Constants.PropertyEditors.ProductPickerAlias);
+
+            foreach (var dataType in dataTypes)
+            {
+                if (dataType.DatabaseType == ValueStorageType.Ntext) continue;
+
+                dataType.DatabaseType = ValueStorageType.Ntext;
+
+                await _dataTypeService.UpdateAsync(dataType, Cms.Core.Constants.Security.SuperUserKey);
+            }
+
+            // Relocate the values that were written while the editor still used string storage. The
+            // "varcharValue IS NOT NULL" guard keeps this idempotent. Copying can be slow on a large
+            // umbracoPropertyData table, so allow more than the default command timeout.
+            // This is what MigrationBase.EnsureLongCommandTimeout does; it is inlined here because
+            // that helper only arrived in Umbraco 17.4 and this package supports 17.0 upwards.
+            const int longCommandTimeoutSeconds = 300;
+            if (Database.CommandTimeout < longCommandTimeoutSeconds)
+            {
+                Database.CommandTimeout = longCommandTimeoutSeconds;
+            }
+
+            await Database.ExecuteAsync(BuildRelocateSql(Database));
+
+            // Saves made while the bug was live wrote the collection's ToString() instead of the ids.
+            // Those ids cannot be recovered, but the text has to go: the value converter deserializes
+            // it as JSON and throws, taking the whole page down until an editor re-picks the products.
+            await Database.ExecuteAsync(BuildClearBrokenValuesSql(Database));
+        }
+
+        // Umbraco's own Dto classes carry these names but are internal to Umbraco.Infrastructure,
+        // so a package has to spell the columns out. The table names are public constants.
+        private const string TextValue = "textValue";
+        private const string VarcharValue = "varcharValue";
+        private const string PropertyTypeId = "propertyTypeId";
+        private const string DataTypeId = "dataTypeId";
+        private const string EditorAlias = "propertyEditorAlias";
+        private const string DbType = "dbType";
+        private const string PropertyTypePrimaryKey = "id";
+        private const string DataTypeNodeId = "nodeId";
+
+        /// <summary>
+        /// Matches every property that uses a product picker data type now stored as Ntext.
+        /// </summary>
+        private static string ProductPickerProperties(ISqlSyntaxProvider syntax) => $@"
+{syntax.GetQuotedColumnName(PropertyTypeId)} IN (
+    SELECT {syntax.GetQuotedColumnName(PropertyTypePrimaryKey)}
+    FROM {syntax.GetQuotedTableName(Cms.Core.Constants.DatabaseSchema.Tables.PropertyType)}
+    WHERE {syntax.GetQuotedColumnName(DataTypeId)} IN (
+        SELECT {syntax.GetQuotedColumnName(DataTypeNodeId)}
+        FROM {syntax.GetQuotedTableName(Cms.Core.Constants.DatabaseSchema.Tables.DataType)}
+        WHERE {syntax.GetQuotedColumnName(EditorAlias)} = '{Constants.PropertyEditors.ProductPickerAlias}'
+        AND {syntax.GetQuotedColumnName(DbType)} = '{nameof(ValueStorageType.Ntext)}'
+    )
+)";
+
+        private static string BuildRelocateSql(IUmbracoDatabase database)
+        {
+            ISqlSyntaxProvider syntax = database.SqlContext.SqlSyntax;
+
+            return $@"
+UPDATE {syntax.GetQuotedTableName(Cms.Core.Constants.DatabaseSchema.Tables.PropertyData)}
+SET {syntax.GetQuotedColumnName(TextValue)} = {syntax.GetQuotedColumnName(VarcharValue)}, {syntax.GetQuotedColumnName(VarcharValue)} = NULL
+WHERE {ProductPickerProperties(syntax)}
+AND {syntax.GetQuotedColumnName(VarcharValue)} IS NOT NULL";
+        }
+
+        private static string BuildClearBrokenValuesSql(IUmbracoDatabase database)
+        {
+            ISqlSyntaxProvider syntax = database.SqlContext.SqlSyntax;
+
+            return $@"
+UPDATE {syntax.GetQuotedTableName(Cms.Core.Constants.DatabaseSchema.Tables.PropertyData)}
+SET {syntax.GetQuotedColumnName(TextValue)} = NULL
+WHERE {ProductPickerProperties(syntax)}
+AND {syntax.GetQuotedColumnName(TextValue)} LIKE 'System.Collections.%'";
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Migrations/RunShopifyMigrations.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Migrations/RunShopifyMigrations.cs
@@ -1,0 +1,44 @@
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade;
+
+namespace Umbraco.Cms.Integrations.Commerce.Shopify.Migrations
+{
+    public class RunShopifyMigrations : INotificationAsyncHandler<UmbracoApplicationStartingNotification>
+    {
+        private readonly ICoreScopeProvider _coreScopeProvider;
+        private readonly IMigrationPlanExecutor _migrationPlanExecutor;
+        private readonly IKeyValueService _keyValueService;
+        private readonly IRuntimeState _runtimeState;
+
+        public RunShopifyMigrations(
+            ICoreScopeProvider coreScopeProvider,
+            IMigrationPlanExecutor migrationPlanExecutor,
+            IKeyValueService keyValueService,
+            IRuntimeState runtimeState)
+        {
+            _coreScopeProvider = coreScopeProvider;
+            _migrationPlanExecutor = migrationPlanExecutor;
+            _keyValueService = keyValueService;
+            _runtimeState = runtimeState;
+        }
+
+        public async Task HandleAsync(UmbracoApplicationStartingNotification notification, CancellationToken cancellationToken)
+        {
+            if (_runtimeState.Level < Cms.Core.RuntimeLevel.Run) return;
+
+            var migrationPlan = new MigrationPlan("Shopify");
+
+            migrationPlan.From(string.Empty)
+                .To<MigrateProductPickerToJsonStorage>("shopify-productpicker-json-storage");
+
+            var upgrader = new Upgrader(migrationPlan);
+
+            await upgrader.ExecuteAsync(_migrationPlanExecutor, _coreScopeProvider, _keyValueService);
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/ShopifyComposer.cs
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/ShopifyComposer.cs
@@ -7,8 +7,10 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 using Umbraco.Cms.Api.Common.OpenApi;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Integrations.Commerce.Shopify.Api.Configuration;
 using Umbraco.Cms.Integrations.Commerce.Shopify.Configuration;
+using Umbraco.Cms.Integrations.Commerce.Shopify.Migrations;
 using Umbraco.Cms.Integrations.Commerce.Shopify.Services;
 
 namespace Umbraco.Cms.Integrations.Commerce.Shopify
@@ -21,6 +23,8 @@ namespace Umbraco.Cms.Integrations.Commerce.Shopify
                 .Bind(builder.Config.GetSection(Constants.Configuration.Settings));
             var oauthOptions = builder.Services.AddOptions<ShopifyOAuthSettings>()
                 .Bind(builder.Config.GetSection(Constants.Configuration.OAuthSettings));
+
+            builder.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, RunShopifyMigrations>();
 
             builder.Services.AddSingleton<ITokenService, TokenService>();
 


### PR DESCRIPTION
> Backport of #326 to the v17 line.

Fixes umbraco/Umbraco.Integrations.Issues#28

## The bug

Saving a page with picked Shopify products worked once. Any later save wrote this into the database:

```
System.Collections.Generic.List`1[System.Int64]
```

and every front-end request then threw `System.Text.Json.JsonException: 'S' is an invalid start of a value` out of `ShopifyProductPickerValueConverter.ConvertSourceToIntermediate`.

## Root cause

`ShopifyProductPickerPropertyEditor` declared no `ValueType`, so it fell back to string storage. Umbraco's `DataValueEditor.TryConvertValueToCrlType` only JSON-serializes when `ValueType` is `Json`; for a string type it calls `TryConvertTo(typeof(string))`, i.e. `ToString()` on the posted `List<long>`.

The first save looked fine because the editor posts a JSON *string*. Only once Umbraco hands the parsed array back to the editor does a re-save take the `ToString()` path — which is exactly the "first publish is fine, subsequent breaks" the reporter described.

## The fix

`ValueType = ValueTypes.Json`.

That moves storage from `varcharValue` to `textValue`, so it needs a migration. `MigrateProductPickerToJsonStorage`:

1. Corrects `dbType` on existing product picker data types to `Ntext`.
2. Relocates existing values to `textValue`.
3. Clears values already corrupted by the bug.

Step 3 matters: those ids are unrecoverable either way, but leaving the text in place keeps the site throwing until an editor re-picks the products. A blank picker beats a dead page.

The SQL follows Umbraco's own `FixLabelDataTypeDbTypeFromConfiguration` (`V_17_4_0`), which solves the same problem for `Umbraco.Label`. Column names are spelled out because Umbraco's DTO classes are internal to `Umbraco.Infrastructure`.

This is the package's first migration, so `RunShopifyMigrations` and its composer registration come with it.

## Validation

Red/green against a real Umbraco 18 site, posting the value the way the backoffice does on a re-save and reading the SQLite columns directly:

| | `dbType` | stored value |
|---|---|---|
| before | `Nvarchar` | `varcharValue = 'System.Collections.Generic.List`1[System.Int64]'` |
| after | `Ntext` | `textValue = '[6541726534523,1283675761235]'` |

The migration was also run for real against a row corrupted by the red run: it flipped the data type to `Ntext`, relocated the value, and cleared the corrupt text.

## Notes

- Not exercised through the picker UI — that needs Shopify credentials. The storage path is server-side and does not touch the Shopify API.
- No version bump or changelog entry — that is release work.
- **This one changes storage, so it deserves a review of the migration against a non-SQLite database before release.**

## Differences from the v18 PR

This line resolves against **Umbraco 17.0.0** (`[17.0.0, 18.0.0)`), so two APIs used on v18 are not available:

- `MigrationBase.EnsureLongCommandTimeout` only exists from 17.4. The three lines it runs are inlined.
- `Constants.DatabaseSchema.Columns` does not exist on 17.0. The two key column names are literals, alongside the ones already spelled out.

Verified: builds clean against the resolved `Umbraco.Cms.Core/17.0.0`.
