### PR TITLE
fix(dynamics): select a form when clicking anywhere on the row

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Client/src/modal/dynamics-form-modal.element.ts
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Client/src/modal/dynamics-form-modal.element.ts
@@ -151,15 +151,11 @@ export default class DynamicsFormModalElement extends UmbModalBaseElement<Dynami
                                     ${repeat(this._filteredForms, (form) => html`
                                         <uui-ref-node-form
                                             selectable
+                                            .deselectable=${false}
                                             ?selected=${this._selectedForm.id == form.id}
                                             name=${form.name ?? ""}
-                                            @click=${() => this._onSelect(form)}
-                                            @keydown=${(e: KeyboardEvent) => {
-                                                if (e.key === ' ' || e.key === 'Enter') {
-                                                    e.preventDefault();
-                                                    this._onSelect(form);
-                                                }
-                                            }}>
+                                            @open=${() => this._onSelect(form)}
+                                            @selected=${() => this._onSelect(form)}>
                                         </uui-ref-node-form>
                                     `)}
                                     <uui-toggle


### PR DESCRIPTION
> Backport of #327 to the v17 line.

Fixes umbraco/Umbraco.Integrations.Issues#23

## The bug

In the Dynamics form picker, clicking a form did not select it. Only part of the row responded.

## Root cause

The list marks each `uui-ref-node-form` as `selectable` but wires up only one event. Those are two different interactions in UUI, and the element splits the row between them.

Measured against UUI 2.0.2 in a browser:

- With `selectable` set, the inner `#open-part` button shrinks to **151px of an 881px row** (`:host([selectable]) #open-part { flex-grow: 0 }`).
- UUI's `SelectableMixin` ignores any click whose composed path contains a `BUTTON`.

So a click on the form name raises `open`, and a click anywhere else on the row raises `selected`. Only one of the two was handled, so most of the row highlighted without the modal recording a choice.

## The fix

Listen for both, and mark the node non-deselectable so a second click on the chosen form cannot silently clear it.

Verified the resulting event coverage in a browser against the same UUI build:

| click target | event raised |
|---|---|
| form name | `open` |
| middle of row | `selected` |
| far right | `selected` |
| already-selected row | `selected` (stays selected) |

## Validation

The UUI interaction is measured and verified. The picker itself is not exercised end to end — that needs Dynamics OAuth, which I did not have.

## Notes

No version bump or changelog entry — that is release work.

## Differences from the v18 PR

This branch did not use `@open`. It used `@click` on the host plus a manual `@keydown` handler.

`@click` on the host never fires for a click on the form name: UUI handles that click on its internal `#open-part` button and calls `stopPropagation`, so it never reaches the host listener. That is precisely the reported symptom of only the outer edge working.

The manual `@keydown` handler goes away — UUI's own mixins already raise `open` and `selected` from the keyboard.

Verified: the client typechecks and builds.
