### PR TITLE
chore: make the V17 test site installable unattended

### DIFF
--- a/examples/Umbraco.Cms.Integrations.Testsite.V17/appsettings.Development.json
+++ b/examples/Umbraco.Cms.Integrations.Testsite.V17/appsettings.Development.json
@@ -33,6 +33,13 @@
       },
       "Hosting": {
         "Debug": true
+      },
+      "Unattended": {
+        "InstallUnattended": true,
+        "UpgradeUnattended": true,
+        "UnattendedUserName": "Admin",
+        "UnattendedUserEmail": "admin@example.com",
+        "UnattendedUserPassword": "1234567890"
       }
     }
   }


### PR DESCRIPTION
> Companion to #328 on the v17 line.

Housekeeping split out of the bug-fix PRs so those stay reviewable.

## Changes

- **Unattended install settings** for the V17 test site's `appsettings.Development.json`. A fresh clone currently boots to the installer; with this it comes up as a usable backoffice, which is what makes automated browser testing against the test site practical.

## Please read before merging

The unattended block contains credentials:

```json
"UnattendedUserEmail": "admin@example.com",
"UnattendedUserPassword": "1234567890"
```

These are throwaway local values for a SQLite database that is not in source control, so they are not a shared secret. They are still credentials in a committed file. Swap them, move them to user secrets, or drop this PR if that is not wanted — the bug-fix PRs do not depend on it.

## Difference from the v18 PR

Settings only. The v17 line has a `.sln` rather than a `.slnx`, which has no display-name attribute, so there is no solution change here.
