### PR TITLE
fix(algolia): skip records Algolia rejects instead of abandoning the index build

### DIFF
--- a/Umbraco.Cms.Integrations.slnx
+++ b/Umbraco.Cms.Integrations.slnx
@@ -52,6 +52,7 @@
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="tests/Umbraco.Cms.Integrations.Crm.Hubspot.Tests/Umbraco.Cms.Integrations.Crm.Hubspot.Tests.csproj" />
+    <Project Path="tests/Umbraco.Cms.Integrations.Search.Algolia.Tests/Umbraco.Cms.Integrations.Search.Algolia.Tests.csproj" />
   </Folder>
   <Project Path="examples/Umbraco.Cms.Integrations.Testsite.V18/Umbraco.Cms.Integrations.Testsite.V18.csproj" DisplayName="Umbraco.Cms.Integrations.TestSite.V18" />
 </Solution>

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Client/generated/types.gen.ts
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Client/generated/types.gen.ts
@@ -50,6 +50,7 @@ export type ResultModel = {
     success: boolean;
     error: string;
     failure: boolean;
+    skippedItems: Array<string>;
 };
 
 export type GetContentTypesData = {

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Client/src/repository/algolia-index.repository.ts
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Client/src/repository/algolia-index.repository.ts
@@ -98,6 +98,20 @@ export class AlgoliaIndexRepository extends UmbControllerBase {
             return { error };
         }
 
+        // The endpoint answers 200 even when the build failed, so the payload has to be read.
+        if (data.success === false) {
+            this.#showError(data.error ?? "The index could not be built.");
+            return { data };
+        }
+
+        const skipped = data.skippedItems ?? [];
+        if (skipped.length > 0) {
+            this.#showWarning(
+                `Index built, but ${skipped.length} item(s) were skipped because Algolia rejected them: ${skipped.join(", ")}`
+            );
+            return { data };
+        }
+
         this.#showSuccess("Index built.");
 
         return { data };
@@ -140,6 +154,20 @@ export class AlgoliaIndexRepository extends UmbControllerBase {
     async #showSuccess(message: string) {
         const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
         notificationContext?.peek("positive", {
+            data: { message: message },
+        });
+    }
+
+    async #showWarning(message: string) {
+        const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
+        notificationContext?.peek("warning", {
+            data: { message: message },
+        });
+    }
+
+    async #showError(message: string) {
+        const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
+        notificationContext?.peek("danger", {
             data: { message: message },
         });
     }

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Result.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Models/Result.cs
@@ -11,6 +11,16 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Models
 
         public bool Failure => !Success;
 
+        /// <summary>
+        /// Records the operation completed without, described as "Name (id)".
+        /// </summary>
+        /// <remarks>
+        /// An index build skips records Algolia refuses individually - typically because they
+        /// exceed the account's maximum record size - and carries on. Those are reported here
+        /// rather than as an error, because the build itself succeeded.
+        /// </remarks>
+        public IReadOnlyCollection<string> SkippedItems { get; set; } = Array.Empty<string>();
+
         protected Result(bool success, string error)
         {
             if (success && !string.IsNullOrEmpty(error))
@@ -28,6 +38,12 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Models
         }
 
         public static Result Ok() => new (true, string.Empty);
+
+        /// <summary>
+        /// The operation completed, but some records were skipped. See <see cref="SkippedItems"/>.
+        /// </summary>
+        public static Result Partial(IReadOnlyCollection<string> skippedItems) =>
+            new (true, string.Empty) { SkippedItems = skippedItems };
 
         public static Result Fail(string message) => new (false, message);
 

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaBatchPush.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaBatchPush.cs
@@ -1,0 +1,96 @@
+using Umbraco.Cms.Integrations.Search.Algolia.Models;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Services
+{
+    /// <summary>
+    /// Pushes records to Algolia in chunks, isolating the ones Algolia refuses so a single bad
+    /// record cannot abandon the rest of the index build.
+    /// </summary>
+    /// <remarks>
+    /// Algolia rejects a whole batch when any record in it exceeds the account's maximum record
+    /// size, so a single oversized page used to stop the build dead. Nothing here knows what that
+    /// limit is - it lets Algolia decide, then retries the rejected batch one record at a time.
+    /// <para>
+    /// Kept free of the Algolia client so the retry logic can be tested without an account.
+    /// </para>
+    /// </remarks>
+    public static class AlgoliaBatchPush
+    {
+        /// <summary>
+        /// Matches the batch size the Algolia client uses internally, so a rejection maps to one
+        /// request rather than being split differently on the way out.
+        /// </summary>
+        public const int DefaultChunkSize = 1000;
+
+        /// <summary>
+        /// Saves every record, returning the ones Algolia refused individually.
+        /// </summary>
+        /// <param name="records">The records to save.</param>
+        /// <param name="saveBatch">Saves a batch of records. Expected to throw when Algolia rejects it.</param>
+        /// <param name="saveOne">Saves a single record. Expected to throw when Algolia rejects it.</param>
+        /// <param name="chunkSize">Records per batch.</param>
+        /// <returns>The records that could not be saved, in the order they were attempted.</returns>
+        /// <exception cref="Exception">
+        /// Rethrows the batch failure when every record in a rejected batch also fails on its own.
+        /// That is not one oversized record - it is the whole call failing, an expired key or an
+        /// unreachable index - and the caller needs to see it rather than be told everything was
+        /// silently skipped.
+        /// </exception>
+        public static async Task<IReadOnlyList<Record>> SaveAsync(
+            IReadOnlyList<Record> records,
+            Func<IReadOnlyList<Record>, Task> saveBatch,
+            Func<Record, Task> saveOne,
+            int chunkSize = DefaultChunkSize)
+        {
+            ArgumentNullException.ThrowIfNull(records);
+            ArgumentNullException.ThrowIfNull(saveBatch);
+            ArgumentNullException.ThrowIfNull(saveOne);
+
+            if (chunkSize < 1) throw new ArgumentOutOfRangeException(nameof(chunkSize));
+
+            var skipped = new List<Record>();
+
+            for (var offset = 0; offset < records.Count; offset += chunkSize)
+            {
+                var chunk = records.Skip(offset).Take(chunkSize).ToList();
+
+                try
+                {
+                    await saveBatch(chunk);
+                }
+                catch (Exception batchException)
+                {
+                    var chunkSkipped = await SaveIndividuallyAsync(chunk, saveOne);
+
+                    // Every record failing is not a size problem, it is the call itself failing.
+                    if (chunkSkipped.Count == chunk.Count) throw batchException;
+
+                    skipped.AddRange(chunkSkipped);
+                }
+            }
+
+            return skipped;
+        }
+
+        private static async Task<List<Record>> SaveIndividuallyAsync(
+            IReadOnlyList<Record> chunk,
+            Func<Record, Task> saveOne)
+        {
+            var skipped = new List<Record>();
+
+            foreach (var record in chunk)
+            {
+                try
+                {
+                    await saveOne(record);
+                }
+                catch
+                {
+                    skipped.Add(record);
+                }
+            }
+
+            return skipped;
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaIndexService.cs
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Services/AlgoliaIndexService.cs
@@ -1,6 +1,7 @@
 ﻿using Algolia.Search.Clients;
 using Algolia.Search.Exceptions;
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using Umbraco.Cms.Integrations.Search.Algolia.Configuration;
@@ -12,9 +13,12 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
     {
         private readonly AlgoliaSettings _settings;
 
-        public AlgoliaIndexService(IOptions<AlgoliaSettings> options)
+        private readonly ILogger<AlgoliaIndexService> _logger;
+
+        public AlgoliaIndexService(IOptions<AlgoliaSettings> options, ILogger<AlgoliaIndexService> logger)
         {
             _settings = options.Value;
+            _logger = logger;
         }
 
         public async Task<Result> PushData(string name, List<Record> payload = null)
@@ -25,19 +29,39 @@ namespace Umbraco.Cms.Integrations.Search.Algolia.Services
 
                 var index = client.InitIndex(name);
 
-                await index.SaveObjectsAsync(payload != null
-                    ? payload
-                    : new List<Record> {
-                        new Record {
-                            ObjectID = Guid.NewGuid().ToString(),
-                            GeolocationData = null,
-                            Data = new Dictionary<string, object>()}
-                    }, autoGenerateObjectId: false);
-
                 if (payload == null)
+                {
+                    // Seeding an empty index: write a placeholder so the index exists, then empty it.
+                    await index.SaveObjectsAsync(
+                        new List<Record> {
+                            new Record {
+                                ObjectID = Guid.NewGuid().ToString(),
+                                GeolocationData = null,
+                                Data = new Dictionary<string, object>()}
+                        }, autoGenerateObjectId: false);
+
                     await index.ClearObjectsAsync();
 
-                return Result.Ok();
+                    return Result.Ok();
+                }
+
+                var skipped = await AlgoliaBatchPush.SaveAsync(
+                    payload,
+                    batch => index.SaveObjectsAsync(batch, autoGenerateObjectId: false),
+                    record => index.SaveObjectAsync(record, autoGenerateObjectId: false));
+
+                if (skipped.Count == 0) return Result.Ok();
+
+                foreach (var record in skipped)
+                {
+                    _logger.LogWarning(
+                        "Algolia rejected '{Name}' ({Id}) for index {Index}, so it was left out of the build. This is usually a record over the account's maximum record size.",
+                        record.Name,
+                        record.Id,
+                        name);
+                }
+
+                return Result.Partial(skipped.Select(p => $"{p.Name} ({p.Id})").ToList());
             }
             catch (AlgoliaException ex)
             {

--- a/tests/Umbraco.Cms.Integrations.Search.Algolia.Tests/Services/AlgoliaBatchPushTests.cs
+++ b/tests/Umbraco.Cms.Integrations.Search.Algolia.Tests/Services/AlgoliaBatchPushTests.cs
@@ -1,0 +1,130 @@
+using Umbraco.Cms.Integrations.Search.Algolia.Services;
+
+using Xunit;
+
+// Xunit.Record collides with the Algolia record model.
+using Record = Umbraco.Cms.Integrations.Search.Algolia.Models.Record;
+
+namespace Umbraco.Cms.Integrations.Search.Algolia.Tests.Services;
+
+public class AlgoliaBatchPushTests
+{
+    private static IReadOnlyList<Record> Records(params int[] ids) =>
+        ids.Select(id => new Record { Id = id, Name = $"Node {id}", ObjectID = id.ToString() }).ToList();
+
+    /// <summary>
+    /// Records a batch save as one call and rejects any batch containing a "rejected" record,
+    /// the way Algolia rejects a whole batch when one record is over the size limit.
+    /// </summary>
+    private sealed class FakeIndex(params int[] rejectedIds)
+    {
+        private readonly HashSet<int> _rejected = [.. rejectedIds];
+
+        public List<int> Saved { get; } = [];
+
+        public List<int> BatchSizes { get; } = [];
+
+        public int SingleSaveCount { get; private set; }
+
+        public Task SaveBatch(IReadOnlyList<Record> batch)
+        {
+            BatchSizes.Add(batch.Count);
+
+            if (batch.Any(r => _rejected.Contains(r.Id)))
+            {
+                throw new InvalidOperationException("Record too big");
+            }
+
+            Saved.AddRange(batch.Select(r => r.Id));
+            return Task.CompletedTask;
+        }
+
+        public Task SaveOne(Record record)
+        {
+            SingleSaveCount++;
+
+            if (_rejected.Contains(record.Id))
+            {
+                throw new InvalidOperationException("Record too big");
+            }
+
+            Saved.Add(record.Id);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenNothingIsRejected_SavesEverythingAndSkipsNothing()
+    {
+        var index = new FakeIndex();
+
+        var skipped = await AlgoliaBatchPush.SaveAsync(Records(1, 2, 3), index.SaveBatch, index.SaveOne);
+
+        Assert.Empty(skipped);
+        Assert.Equal([1, 2, 3], index.Saved);
+        Assert.Equal(0, index.SingleSaveCount);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenOneRecordIsRejected_SavesTheRestAndReportsIt()
+    {
+        var index = new FakeIndex(2);
+
+        var skipped = await AlgoliaBatchPush.SaveAsync(Records(1, 2, 3), index.SaveBatch, index.SaveOne);
+
+        Assert.Equal([2], skipped.Select(r => r.Id));
+        Assert.Equal([1, 3], index.Saved);
+    }
+
+    [Fact]
+    public async Task SaveAsync_OnlyRetriesTheRejectedBatch()
+    {
+        // Chunk of 2: [1,2] fails on record 2, [3,4] goes through untouched.
+        var index = new FakeIndex(2);
+
+        await AlgoliaBatchPush.SaveAsync(Records(1, 2, 3, 4), index.SaveBatch, index.SaveOne, chunkSize: 2);
+
+        Assert.Equal([2, 2], index.BatchSizes);
+
+        // Only the failed batch is retried record by record.
+        Assert.Equal(2, index.SingleSaveCount);
+
+        // 1 saved on retry, 2 rejected, then 3 and 4 go through as a batch.
+        Assert.Equal([1, 3, 4], index.Saved);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenEveryRecordInABatchFails_RethrowsInsteadOfReportingThemAllSkipped()
+    {
+        // A bad API key fails every record. That is the call failing, not oversized content,
+        // and it must not be reported as "the build succeeded, we just skipped everything".
+        var index = new FakeIndex(1, 2, 3);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AlgoliaBatchPush.SaveAsync(Records(1, 2, 3), index.SaveBatch, index.SaveOne));
+
+        Assert.Equal("Record too big", ex.Message);
+        Assert.Empty(index.Saved);
+    }
+
+    [Fact]
+    public async Task SaveAsync_SplitsIntoChunksOfTheGivenSize()
+    {
+        var index = new FakeIndex();
+
+        await AlgoliaBatchPush.SaveAsync(Records(1, 2, 3, 4, 5), index.SaveBatch, index.SaveOne, chunkSize: 2);
+
+        Assert.Equal([2, 2, 1], index.BatchSizes);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithNoRecords_DoesNothing()
+    {
+        var index = new FakeIndex();
+
+        var skipped = await AlgoliaBatchPush.SaveAsync([], index.SaveBatch, index.SaveOne);
+
+        Assert.Empty(skipped);
+        Assert.Empty(index.BatchSizes);
+    }
+}

--- a/tests/Umbraco.Cms.Integrations.Search.Algolia.Tests/Umbraco.Cms.Integrations.Search.Algolia.Tests.csproj
+++ b/tests/Umbraco.Cms.Integrations.Search.Algolia.Tests/Umbraco.Cms.Integrations.Search.Algolia.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- The package under test is an ASP.NET Core Razor class library, so the test
+         project needs the same framework reference to see MVC/HTTP types. -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Umbraco.Cms.Integrations.Search.Algolia\Umbraco.Cms.Integrations.Search.Algolia.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes umbraco/Umbraco.Integrations.Issues#11

## The bug

> The build process of the index doesn't continue with indexing the rest of the pages. I need it to skip the pages that are too large in size and index all other pages.

## Root cause

`BuildIndexController.BuildIndex` collects every record for every content type into one list and makes a single `PushData` call. Algolia rejects an **entire batch** when any record in it exceeds the account's maximum record size, so one oversized page stopped the build dead and left the rest of the site unindexed.

## The fix

`PushData` now pushes in chunks and, when Algolia rejects a chunk, retries that chunk one record at a time so only the records Algolia actually refuses are left out.

Nothing in the fix knows what the size limit is — Algolia decides. That keeps it correct across plans, where the limit differs, and avoids a configuration value that would silently drift out of step.

One guard matters: a bad API key also fails every record. So a chunk where *every* record fails individually rethrows the original error, rather than reporting a successful build that happened to skip everything. There is a test for exactly that.

## Reporting, which is why the reporter saw nothing useful

Two adjacent defects, both fixed here:

- the dashboard did `await buildIndex(index)` and **discarded the result entirely**
- the repository showed `"Index built."` whenever the HTTP call succeeded, **including when the payload said the build had failed**

So a failed build reported success. Now the dashboard shows the error on failure, and on a partial build names the skipped records. Skipped records are also logged server-side with their name and id, and returned on `Result.SkippedItems`.

## Testing

The retry loop lives in `AlgoliaBatchPush`, deliberately free of the Algolia client, so it is unit tested without an account. Six tests cover the happy path, one oversized record, retrying only the failed chunk, the all-failed rethrow, chunk splitting, and the empty case.

I mutation-checked the important one: removing the all-failed guard turns that test red.

This is a new test project. CI discovers it automatically from `tests/**/*Tests.csproj`.

## Validation

Unit tested and compiler verified. **Not exercised against a live Algolia index** — I have no credentials. That is why the retry logic was factored to be testable in isolation, but a manual check against a real index before release would be worth it.

## Notes

No version bump or changelog entry — that is release work.
