### PR TITLE
fix(dynamics): skip the access token column resize on SQLite

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Migrations/EnsureAccessTokenColumnLength.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Migrations/EnsureAccessTokenColumnLength.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using NPoco;
 using Umbraco.Cms.Infrastructure.Migrations;
 
 namespace Umbraco.Cms.Integrations.Crm.Dynamics.Migrations
@@ -12,6 +13,15 @@ namespace Umbraco.Cms.Integrations.Crm.Dynamics.Migrations
         protected override void Migrate()
         {
             Logger.LogDebug("Running migration {0}", nameof(EnsureAccessTokenColumnLength));
+
+            // SQLite has no ALTER COLUMN, and does not need one: it types values dynamically, so
+            // VARCHAR(n) never enforced a length there and an access token of any size already
+            // stored fine. Without this guard the step throws on every startup, which also stops
+            // the plan ever recording its final state.
+            if (DatabaseType == DatabaseType.SQLite)
+            {
+                return;
+            }
 
             Alter.Table(Constants.DynamicsOAuthConfigurationTable)
                 .AlterColumn(nameof(DynamicsOAuthConfigurationTable.AccessToken))


### PR DESCRIPTION
> Backport of #336 to the v17 line.

No issue for this one — I hit it while testing the other fixes. Every startup of the test site against SQLite logged this:

```
[ERR] Plan DynamicsOAuthMigrationPlan failed at step dynamicsOAuthConfiguration-alter-access-token-column-length-db
System.NotSupportedException: SQLite does not support ALTER TABLE operations. Instead you will have to:
1. Create a temp table.
...
   at Umbraco.Cms.Integrations.Crm.Dynamics.Migrations.EnsureAccessTokenColumnLength.Migrate()
```

## Root cause

`EnsureAccessTokenColumnLength` widens `dynamicsOAuthConfiguration.AccessToken` to 4000 characters using `Alter.Table(...).AlterColumn(...)`. Umbraco's SQLite syntax provider refuses ALTER COLUMN outright.

## Why it is more than log noise

Because the step throws, the plan never records its final state. It sits one step short indefinitely, retrying and failing on every boot — and any step added to `DynamicsMigrationPlan` after this one would never run either.

## The fix

Skip the step on SQLite. That is not a workaround: SQLite types values dynamically, so `VARCHAR(n)` never enforced a length there and an access token of any size already stored fine. There is genuinely nothing for the migration to do.

Umbraco core reached the same conclusion for the same reason in `V_17_3_0.IncreaseSizeOfLongRunningOperationTypeColumn`, which opens with:

```csharp
// SQLite doesn't need this - text is already unlimited
if (DatabaseType == DatabaseType.SQLite)
{
    return Task.CompletedTask;
}
```

The guard here is copied from it.

SQL Server behaviour is unchanged.

## Validation

Against the SQLite test site, before and after.

| | recorded plan state | startup log |
|---|---|---|
| before | `dynamicsOAuthConfiguration-db` | `NotSupportedException` every boot |
| after | `dynamicsOAuthConfiguration-alter-access-token-column-length-db` | `Execute EnsureAccessTokenColumnLength` then `Done` |

Not verified against SQL Server — but that path is untouched, and it is the path that already worked.

## Notes

I did not add the extra `INFORMATION_SCHEMA` length probe that the core migration carries. Core needs it because that migration can be re-entered; this one is recorded on success, so it is not.

No version bump or changelog entry — that is release work.

## Difference from the v18 PR

This line's migration derives from the synchronous `MigrationBase` rather than `AsyncMigrationBase`, so the guard is a plain `return` instead of `return Task.CompletedTask`. Otherwise identical.

Verified it builds against the resolved `Umbraco.Cms.Core/17.0.0`, the floor for this line.
