### PR TITLE
ci: name the build after the branch, not one arbitrary package

### DIFF
--- a/.azure-pipelines/templates/pack-product.yml
+++ b/.azure-pipelines/templates/pack-product.yml
@@ -80,7 +80,13 @@ steps:
           Write-Host "##vso[task.prependpath]$HOME/.dotnet/tools"
       displayName: "Install NBGV"
 
-    - pwsh: nbgv cloud --all-vars
+    # --skip-cloud-build-number: every job in the matrix runs this, and without
+    # the flag each one would overwrite the build number with its own package's
+    # version. The `name:` in azure-pipelines.yml names the build instead.
+    # The NBGV_* variables this still publishes are only for reading in the log;
+    # the package version itself comes from the Nerdbank.GitVersioning MSBuild
+    # targets (a GlobalPackageReference), not from here.
+    - pwsh: nbgv cloud --all-vars --skip-cloud-build-number
       displayName: "Set version from version.json"
       workingDirectory: ${{ parameters.productPath }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,7 @@ Still **one pipeline per package**, path-filtered to `src/<project>/**`.
 - **`NU1507`** is expected on the v18 line: central package management plus the two feeds in `NuGet.config`. A warning, not an error; silencing it needs package source mapping.
 - **`dotnet test` arguments.** Do not pass `--logger`/`--results-directory` alongside `publishTestResults: true` — the `DotNetCoreCLI@2` task appends its own pair and `dotnet test` rejects two values for `--results-directory`.
 - **NBGV needs full history.** Every job that builds a package must `checkout` with `fetchDepth: 0`; the agent default is a depth-1 fetch and NBGV throws "Shallow clone lacks the objects required to calculate version height".
+- **The build number is set by `name:`, not by NBGV.** `nbgv cloud` sets the cloud build number by default — the `"cloudBuild": { "buildNumber": { "enabled": false } }` in each `version.json` does **not** stop it, as that setting only governs the MSBuild integration. Every Pack matrix job runs the CLI, so without `--skip-cloud-build-number` the last job to finish names the whole build after its own package (builds on one branch varied between `7.0.1--preview.38...` and `6.0.1--preview.40...`). The flag is passed in `pack-product.yml` and `name:` in `azure-pipelines.yml` supplies `branch-date-buildid` instead. `Umbraco.Automate`/`Umbraco.AI` reach the same result with a `SetBuildNumber` stage that runs after Pack.
 
 ---
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,13 @@
 # Adding a package needs no change to this file: give the new folder a
 # version.json and it is picked up automatically.
 
+# A build packs several packages at different versions, so there is no single
+# version to name it after. Without this, each Pack matrix job's `nbgv cloud`
+# would set the build number to its OWN package's version and the last job to
+# finish would win - naming the whole build after one arbitrary package. The
+# pack template passes --skip-cloud-build-number so this value survives.
+name: $(SourceBranchName)-$(Date:yyyyMMdd)-$(BuildID)
+
 trigger:
     branches:
         include:


### PR DESCRIPTION
## What

Names the Azure build number after the branch instead of after one arbitrary package.

## Why

Every Pack matrix job runs `nbgv cloud`, which sets the cloud build number by default. Each job set it to **its own** package's version, so the last job to finish named the whole build. Two builds on the same branch came out as:

| Branch | Build number | Package it actually named |
|---|---|---|
| `v18/dev` | `6.0.1--preview.40+88e41bb` | Crm.Dynamics |
| `v18/dev` | `7.0.1--preview.38+d109fc6` | Search.Algolia |

A build packs several packages at different versions, so no single version can name it.

The `"cloudBuild": { "buildNumber": { "enabled": false } }` already in every `version.json` does **not** prevent this — that setting governs the Nerdbank.GitVersioning MSBuild integration, not the `nbgv cloud` CLI.

## How

- `pack-product.yml` passes `--skip-cloud-build-number`.
- `azure-pipelines.yml` gains `name: $(SourceBranchName)-$(Date:yyyyMMdd)-$(BuildID)`.

Produces the same format `Umbraco.Automate` and `Umbraco.AI` get from their post-Pack `SetBuildNumber` stage, without the extra stage, and the number is correct from the start rather than wrong until the build finishes.

## Risk

Low. Nothing in the pipeline reads the `NBGV_*` or `Git*` variables, and the package version comes from the Nerdbank.GitVersioning MSBuild targets (a `GlobalPackageReference`), not from this step.

Verified locally that the flag suppresses only the build number:

```
=== without the flag ===
##vso[build.updatebuildnumber]7.0.3.1+9869de2
##vso[task.setvariable variable=NBGV_NuGetPackageVersion;]7.0.3-g9869de2

=== with --skip-cloud-build-number ===
##vso[task.setvariable variable=NBGV_NuGetPackageVersion;]7.0.3-g9869de2
```

No package versions change, so nothing here triggers a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)