### PR TITLE
fix(dynamics): embed the real-time form HTML when Dynamics returns no cached form URL

### DIFF
--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/CHANGELOG.md
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.0.3] - Unreleased
 
+### fix
+
+* Render a real-time form in the iframe when Dynamics returns no `data-cached-form-url`. The standalone URL was empty in that case, so the iframe loaded nothing; the form HTML is now embedded via `srcdoc` and falls back to the raw form HTML when no standalone HTML is returned. Reported in [#257](https://github.com/umbraco/Umbraco.Cms.Integrations/pull/257)
+
 ### Internal
 
 * Development version bump after the 5.0.2 release.

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Editors/DynamicsFormPickerValueConverter.cs
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Editors/DynamicsFormPickerValueConverter.cs
@@ -57,7 +57,7 @@ namespace Umbraco.Cms.Integrations.Crm.Dynamics.Editors
                 var form = _dynamicsService.GetRealTimeForm(jsonObj["id"].ToString()).ConfigureAwait(false).GetAwaiter().GetResult();
                 if (form != null)
                 {
-                    vm.Html = form.StandaloneHtml;
+                    vm.Html = !string.IsNullOrWhiteSpace(form.StandaloneHtml) ? form.StandaloneHtml : form.RawHtml;
                 }
             }
 

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Views/Dynamics/Render/DynamicsForm.cshtml
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Views/Dynamics/Render/DynamicsForm.cshtml
@@ -33,7 +33,14 @@
     {
         @if (Model.IframeEmbedded)
         {
-            <iframe frameBorder="0" style="width:100%;height:100%;" id=@id src="@Model.StandaloneUrl"></iframe>
+            @if (!string.IsNullOrEmpty(Model.StandaloneUrl))
+            {
+                <iframe frameBorder="0" style="width:100%;height:100%;" id=@id src="@Model.StandaloneUrl"></iframe>
+            }
+            else
+            {
+                <iframe frameBorder="0" style="width:100%;height:100%;" id=@id srcdoc="@Model.Html"></iframe>
+            }
         }
         else
         {


### PR DESCRIPTION
Ports #257 onto the v17 line. That PR targets the legacy `main` branch (Umbraco 8 to 13, Dynamics 1.3.7), so it never reached the versions people install today. The bug is still present on both active lines.

Original work and diagnosis by @EelmanE.

## The bug

`FormViewModel.StandaloneUrl` derives the iframe source by scanning the returned form HTML for a `data-cached-form-url` attribute:

```csharp
var dataCachedFromUrl = Html.Split(' ').FirstOrDefault(p => p.Contains("data-cached-form-url"));
if (string.IsNullOrEmpty(dataCachedFromUrl))
{
    return string.Empty;
}
```

Dynamics real-time forms do not always return that attribute. When they do not, the property returns an empty string and the view renders `<iframe src="">`, so nothing loads. Nothing is logged.

## The change

- `DynamicsForm.cshtml` falls back to `srcdoc="@Model.Html"` when `StandaloneUrl` is empty, so the returned form HTML is embedded directly.
- `DynamicsFormPickerValueConverter` falls back to `form.RawHtml` when the API returns no `StandaloneHtml`. `GetRealTimeForm` already populates both.

The non-iframe branch is untouched.

## Deviations from #257

- `string.IsNullOrWhiteSpace` instead of `??` on the converter. `StandaloneHtml` comes back as an empty string rather than null in some responses, and `??` does not catch that.
- Nested `@if` rather than a bare `if`, to match the surrounding markup in the same file.
- #257 does not patch `RenderV8/DynamicsForm.cshtml`, which carries the same broken line on `main`. That file does not exist on this line, so nothing to port.

## Worth a reviewer's opinion

`srcdoc` content inherits the host page's origin, so scripts in the Dynamics HTML can reach the parent document. A cross-origin `src` cannot. Editors pick the iframe option partly for that isolation, so this fallback quietly gives them less of it.

Two options if that matters: add a `sandbox` attribute to the fallback iframe, or document the difference. I have done neither here to keep this a faithful port. Happy to add either.

## Verification

- `dotnet build` on the package: 0 errors.
- The view is not Razor-compiled at build time on this repo (shipped as content, compiled by Umbraco at runtime), so the build does not check it. I compiled `DynamicsForm.cshtml` separately through the Razor source generator against the Razor SDK used by this line: 0 errors, and the generated code confirms `srcdoc` is emitted as an HTML-encoded attribute. As a control, a deliberately broken copy of the same view produced 6 errors through the same path, so the check was real.
- Not reproduced against a live Dynamics tenant. I have no tenant that returns a form without `data-cached-form-url`. @EelmanE hit this in production.

Companion PR for the v18 line: #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
