### PR TITLE
fix(ci): declare releases with a manifest instead of inferring from version.json

### DIFF
--- a/.azure-pipelines/scripts/detect-changes.ps1
+++ b/.azure-pipelines/scripts/detect-changes.ps1
@@ -7,15 +7,34 @@
 # The packages in this repo are independent siblings - none reference another -
 # so there is deliberately no dependency graph and no build ordering here.
 # A package is "a package" if it has both a .csproj and a version.json.
+#
+# On a release or hotfix branch there are two layers, because "what changed" and
+# "what are we publishing" are different questions:
+#
+#   1. Detection compares each package against the released state on main-v<N>,
+#      ignoring release bookkeeping (version.json, CHANGELOG.md). It PROPOSES.
+#   2. release-manifest.json DECIDES. Required on release/*, optional on
+#      hotfix/*. Its 'include' list replaces the build set outright, and anything
+#      detection found changed must appear in 'include' or 'exclude' or the build
+#      fails.
+#
+# Selecting on "version.json differs from main-v<N>" was tried first and does not
+# work. /post-release-cleanup bumps each released package's patch on dev, so that
+# test reported every previously-released package as shipping on every subsequent
+# release branch, while a package whose version had never moved could not be
+# selected at all. This arrangement mirrors Umbraco.AI.
 # ============================================================================
 
 param(
     [string]$SourceBranch = $env:BUILD_SOURCEBRANCH,
     [string]$RootPath = (Get-Location).Path,
 
-    # Overrides the "last released state" ref that a release/hotfix build compares
-    # against. Defaults to origin/main-v<N>, derived from the branch. Exists so the
-    # release-selection logic can be exercised locally without pushing a branch.
+    # Overrides the "last released state" ref that a release/hotfix build computes
+    # its merge-base against. Defaults to origin/main-v<N>, derived from the branch.
+    #
+    # This is load-bearing, not a debug convenience: there are no automated tests
+    # for the selection logic, so /release-management dry-runs this script with
+    # this parameter before pushing a release branch. Keep it working.
     [string]$ReleaseCompareRef = ""
 )
 
@@ -105,18 +124,50 @@ function Test-IsReleaseBranch {
     return $SourceBranch -match '^refs/heads/v\d+/(release|hotfix)/'
 }
 
-function Get-ReleaseProducts {
+# Files a release touches as bookkeeping rather than as a change. A package whose
+# only diff since the released state is one of these has nothing new to publish.
+#
+# This is the whole fix for the carry-over problem: /post-release-cleanup bumps
+# each released package's patch on dev so preview builds sort above the release,
+# and that bump used to make the package look like it was shipping on every
+# release branch cut afterwards, forever.
+#
+# Client/public/umbraco-package.json is deliberately NOT here. It also declares
+# the backoffice extensions, so ignoring it wholesale would hide a real change
+# such as adding an entry point. It is kept at a fixed placeholder version
+# instead, so a release never touches it - see UpdatePackageManifestVersion in
+# the root Directory.Build.targets, which stamps the real version into the
+# wwwroot copy on CI builds.
+$NonSubstantiveFiles = @("version.json", "CHANGELOG.md")
+
+function Test-SubstantiveChange {
     <#
     .SYNOPSIS
-    On a release/hotfix branch, selects the packages that have a new version to
-    publish - those whose version.json differs from the released state on main-v<N>.
+    True when a changed file represents real content rather than release bookkeeping.
+    #>
+    param([string]$FilePath)
+
+    return $NonSubstantiveFiles -notcontains (Split-Path $FilePath -Leaf)
+}
+
+function Get-ReleaseChangedProducts {
+    <#
+    .SYNOPSIS
+    On a release/hotfix branch, reports which packages have substantive changes
+    since the released state on main-v<N>.
 
     .DESCRIPTION
-    This is what makes a release-manifest.json unnecessary. A release branch exists
-    to publish specific packages, and what marks a package as "being released" is a
-    bumped version.json. Comparing against main-v<N> (the last released state)
-    therefore yields exactly the set to build and pack, and never picks up a package
-    that merely has unreleased code changes.
+    This is a cross-check, not the decision. It exists so that a package which
+    genuinely changed cannot be left out of release-manifest.json by accident.
+    The manifest decides what actually packs - see Get-ManifestSelection.
+
+    Comparison is against main-v<N> rather than each package's own release tag
+    (which is what Umbraco.AI does) because this repo's tag slugs are not
+    consistent: both release/crm-activecampaign-* and release/crm-active-campaign-*
+    exist, as do both release/shopify-1.2.0 and release/commerce-shopify-*.
+    main-v<N> is the last released state for the line and /post-release-cleanup
+    always merges into it, so it carries the same information with no slug
+    guessing.
     #>
     param(
         [hashtable]$Products,
@@ -135,36 +186,213 @@ function Get-ReleaseProducts {
         $releasedRef = "origin/main-$line"
     }
 
-    Write-Host "  Release branch build - selecting packages bumped vs $releasedRef" -ForegroundColor Cyan
+    Write-Host "  Release branch build - detecting substantive changes vs $releasedRef" -ForegroundColor Cyan
+
+    $base = git merge-base $releasedRef HEAD 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        # Without a base there is nothing to compare, so report everything as
+        # changed. On a release branch the manifest still constrains what packs,
+        # so this degrades to "the cross-check is uninformative" rather than
+        # "everything ships".
+        Write-Host "  ! merge-base with $releasedRef failed - treating all packages as changed" -ForegroundColor Yellow
+        $Products.Keys | ForEach-Object { $changed[$_] = $true }
+        return $changed
+    }
+
+    $base = $base.Trim()
+    Write-Host "  Comparing $base..HEAD" -ForegroundColor Gray
 
     foreach ($name in ($Products.Keys | Sort-Object)) {
-        $versionFile = "$($Products[$name].Path)/version.json"
-
-        $releasedJson = git show "${releasedRef}:${versionFile}" 2>$null
+        $files = git diff --name-only "$base..HEAD" -- $Products[$name].Path 2>&1
         if ($LASTEXITCODE -ne 0) {
-            # No version.json on the released ref yet - new to this line, so release it.
+            Write-Host "  ! $name - git diff failed, treating as changed" -ForegroundColor Yellow
             $changed[$name] = $true
-            Write-Host "  * $name is new on $releasedRef - including" -ForegroundColor Green
             continue
         }
 
-        $releasedVersion = ($releasedJson | ConvertFrom-Json).version
-        $currentVersion = (Get-Content $versionFile -Raw | ConvertFrom-Json).version
+        $files = @($files | Where-Object { $_ -is [string] -and $_ })
+        $substantive = @($files | Where-Object { Test-SubstantiveChange -FilePath $_ })
 
-        if ($releasedVersion -ne $currentVersion) {
+        if ($substantive.Count -gt 0) {
             $changed[$name] = $true
-            Write-Host "  * $name $releasedVersion -> $currentVersion" -ForegroundColor Green
+            Write-Host "  * $name changed ($($substantive.Count) file(s), e.g. $($substantive[0]))" -ForegroundColor Green
+        }
+        elseif ($files.Count -gt 0) {
+            Write-Host "    $name release bookkeeping only ($($files.Count) file(s)) - not a change" -ForegroundColor Gray
         }
         else {
-            Write-Host "    $name unchanged at $currentVersion" -ForegroundColor Gray
+            Write-Host "    $name unchanged" -ForegroundColor Gray
         }
-    }
-
-    if (-not ($changed.Values | Where-Object { $_ })) {
-        throw "No package has a bumped version.json compared with $releasedRef. A release branch must bump at least one package - run /release-management."
     }
 
     return $changed
+}
+
+function Resolve-ManifestPackageNames {
+    <#
+    .SYNOPSIS
+    Maps names from release-manifest.json to discovered package keys.
+
+    .DESCRIPTION
+    Matching is case-insensitive and returns the canonical git-tracked key. That
+    is deliberate: git tracks
+    ...SEO.GoogleSearchConsole.URLInspectionTool while working copies have
+    appeared on disk as ...UrlInspectionTool, and a human writing the manifest
+    should not have to know which casing won.
+    #>
+    param(
+        [object[]]$Names,
+        [string]$ListName,
+        [hashtable]$Products
+    )
+
+    $byLower = @{}
+    $Products.Keys | ForEach-Object { $byLower[$_.ToLower()] = $_ }
+
+    $keys = @()
+    foreach ($item in $Names) {
+        if ($item -isnot [string] -or [string]::IsNullOrWhiteSpace($item)) {
+            throw "release-manifest.json '$ListName' must contain only non-empty strings"
+        }
+
+        $key = $byLower[$item.Trim().ToLower()]
+        if (-not $key) {
+            throw "release-manifest.json '$ListName' names a package that does not exist or is not packable: $item"
+        }
+
+        if ($keys -notcontains $key) { $keys += $key }
+    }
+
+    return $keys
+}
+
+function Get-ReleaseManifest {
+    <#
+    .SYNOPSIS
+    Loads and validates release-manifest.json. Returns $null when absent.
+
+    .DESCRIPTION
+    Object form only: { "include": [...], "exclude": [...] }. Umbraco.AI also
+    accepts a bare array for backwards compatibility; there is no such history
+    here, so it is not supported.
+
+    The manifest carries names only, never versions - version.json stays the
+    single source of truth for those.
+    #>
+    param(
+        [string]$RootPath,
+        [hashtable]$Products
+    )
+
+    $manifestPath = Join-Path $RootPath "release-manifest.json"
+    if (-not (Test-Path $manifestPath)) { return $null }
+
+    $raw = Get-Content $manifestPath -Raw
+    try {
+        $manifest = $raw | ConvertFrom-Json
+    }
+    catch {
+        throw "Failed to parse release-manifest.json: $($_.Exception.Message)"
+    }
+
+    if ($null -eq $manifest -or $manifest -isnot [psobject] -or
+        $manifest.PSObject.Properties.Name -notcontains 'include') {
+        throw "release-manifest.json must be an object with an 'include' property, e.g. { `"include`": [`"Umbraco.Cms.Integrations.Crm.Dynamics`"] }"
+    }
+
+    $includeKeys = Resolve-ManifestPackageNames -Names @($manifest.include) -ListName "include" -Products $Products
+
+    $excludeKeys = @()
+    if ($manifest.PSObject.Properties.Name -contains 'exclude' -and $null -ne $manifest.exclude) {
+        $excludeKeys = Resolve-ManifestPackageNames -Names @($manifest.exclude) -ListName "exclude" -Products $Products
+    }
+
+    $overlap = @($includeKeys | Where-Object { $excludeKeys -contains $_ })
+    if ($overlap.Count -gt 0) {
+        throw "release-manifest.json lists the same package in both 'include' and 'exclude': $($overlap -join ', ')"
+    }
+
+    if ($includeKeys.Count -eq 0) {
+        throw "release-manifest.json 'include' must name at least one package - a release branch exists to publish something"
+    }
+
+    return @{ Include = $includeKeys; Exclude = $excludeKeys }
+}
+
+function Get-ManifestSelection {
+    <#
+    .SYNOPSIS
+    Applies release-manifest.json to the detected change set and returns the
+    final selection.
+
+    .DESCRIPTION
+    Required on v<N>/release/*, optional on v<N>/hotfix/*, ignored everywhere
+    else. When present it is the decision: 'include' replaces the build list
+    outright, so a package with no changes at all still packs if listed. That is
+    what lets a package which has never shipped be released without first
+    inventing a version bump for it.
+
+    Detection stays useful as a guard: anything it found changed must appear in
+    'include' or 'exclude', or this throws. Forgetting a package is the expensive
+    mistake, so it is the one made loud.
+    #>
+    param(
+        [hashtable]$Products,
+        [hashtable]$Changed,
+        [string]$SourceBranch,
+        [string]$RootPath
+    )
+
+    $isRelease = $SourceBranch -match '^refs/heads/v\d+/release/'
+    $isHotfix = $SourceBranch -match '^refs/heads/v\d+/hotfix/'
+
+    if (-not ($isRelease -or $isHotfix)) { return $Changed }
+
+    $manifest = Get-ReleaseManifest -RootPath $RootPath -Products $Products
+
+    if (-not $manifest) {
+        if ($isRelease) {
+            throw "release-manifest.json is required on a release branch. Run /release-management, or generate it with scripts/generate-release-manifest.ps1."
+        }
+
+        Write-Host ""
+        Write-Host "  Hotfix branch with no release-manifest.json - using change detection" -ForegroundColor Gray
+        return $Changed
+    }
+
+    Write-Host ""
+    Write-Host "Applying release-manifest.json..." -ForegroundColor Cyan
+
+    $changedKeys = @($Changed.Keys | Where-Object { $Changed[$_] })
+    $unaccounted = @($changedKeys | Where-Object {
+        $manifest.Include -notcontains $_ -and $manifest.Exclude -notcontains $_
+    })
+
+    if ($unaccounted.Count -gt 0) {
+        throw "release-manifest.json does not account for changed package(s) - add each to 'include' or 'exclude': $(($unaccounted | Sort-Object) -join ', ')"
+    }
+
+    if ($manifest.Exclude.Count -gt 0) {
+        Write-Host "  Explicitly excluded: $(($manifest.Exclude | Sort-Object) -join ', ')" -ForegroundColor DarkYellow
+    }
+
+    $selected = @{}
+    $Products.Keys | ForEach-Object { $selected[$_] = $false }
+    foreach ($key in $manifest.Include) { $selected[$key] = $true }
+
+    Write-Host "  Releasing: $(($manifest.Include | Sort-Object) -join ', ')" -ForegroundColor Yellow
+
+    # A package in 'include' that detection saw no change in is legitimate - it is
+    # how a never-released package ships, and how a rebuild of an already
+    # merged-back release branch still works - but say so, because the other
+    # reason to see this is a mistake.
+    foreach ($key in ($manifest.Include | Sort-Object)) {
+        if (-not $Changed[$key]) {
+            Write-Host "  note: $key has no substantive changes but is being released" -ForegroundColor DarkYellow
+        }
+    }
+
+    return $selected
 }
 
 function Get-ComparisonBase {
@@ -272,9 +500,10 @@ function Get-ChangedProducts {
     Write-Host ""
     Write-Host "Detecting changes..." -ForegroundColor Cyan
 
-    # A release/hotfix branch publishes whatever it bumped, not whatever it touched.
+    # A release/hotfix branch compares against the released state rather than
+    # against a previous commit, and ignores release bookkeeping when doing so.
     if (Test-IsReleaseBranch -SourceBranch $SourceBranch) {
-        return Get-ReleaseProducts -Products $Products -SourceBranch $SourceBranch -CompareRef $ReleaseCompareRef
+        return Get-ReleaseChangedProducts -Products $Products -SourceBranch $SourceBranch -CompareRef $ReleaseCompareRef
     }
 
     $base = Get-ComparisonBase -SourceBranch $SourceBranch
@@ -383,6 +612,11 @@ Write-Host ""
 
 $products = Get-Products -RootPath $RootPath
 $changed = Get-ChangedProducts -Products $products -SourceBranch $SourceBranch
+
+# Detection proposes; on a release/hotfix branch the manifest decides.
+$changed = Get-ManifestSelection -Products $products -Changed $changed `
+    -SourceBranch $SourceBranch -RootPath $RootPath
+
 Write-PipelineVariables -Products $products -Changed $changed
 
 Write-Host ""

--- a/.claude/skills/post-release-cleanup/SKILL.md
+++ b/.claude/skills/post-release-cleanup/SKILL.md
@@ -10,13 +10,15 @@ You close out a release for **Umbraco.Cms.Integrations**.
 ## Where this sits in the flow
 
 ```
-1. /release-management        - cuts v18/release/YYYY.MM.N, bumps version.json
+1. /release-management        - cuts v18/release/YYYY.MM.N, writes
+                               release-manifest.json, bumps version.json
                                + CHANGELOG there, pushes the branch
 2. CI builds the release branch -> clean 7.1.0 artifacts
 3. Promote to NuGet           (manual)
 4. Tag release/<slug>-<version> (manual)
 5. GitHub release per tag     (manual)
-6. THIS SKILL                 - merge back, bump dev patches, tidy up
+6. THIS SKILL                 - delete the manifest, merge back, bump dev
+                               patches, tidy up
 ```
 
 ## When to run
@@ -38,8 +40,10 @@ Adapted from `Umbraco.AI`'s skill of the same name, minus:
 - **Major-version cutover.** A new Umbraco major gets a deliberately created
   `main-v<N>` / `v<N>/dev` pair as a planning decision. Never create those branches
   or change the repo's default branch from this skill.
-- **`release-manifest.json` deletion.** This repo has no manifest, so there is
-  nothing to clean up after the merge.
+- **Git hooks.** `Umbraco.AI` deletes `release-manifest.json` with a `.githooks`
+  post-merge hook. This repo has no `.githooks` directory, and adding one would
+  mean every contributor has to set `core.hooksPath` or the cleanup silently stops
+  happening. Phase 2 does it explicitly instead.
 
 ---
 
@@ -108,9 +112,26 @@ Options:
 
 ---
 
-## Phase 2: Merge into main-v&lt;N&gt;
+## Phase 2: Delete the manifest, then merge into main-v&lt;N&gt;
 
-Confirm before the first push - this updates a shared branch.
+`release-manifest.json` belongs only to the release branch. It is **required** on
+`v<N>/release/*`, so leaving it in place would carry it onto `main-v<N>` and
+`v<N>/dev`, where it is meaningless and where the next release branch would
+inherit a stale copy naming last release's packages.
+
+Delete it on the release branch first, so both merges are clean:
+
+```bash
+git checkout "$release_branch"
+git rm release-manifest.json
+git commit -m "chore(release): Remove release manifest after publishing"
+git push origin "$release_branch"
+```
+
+If the file is already absent, say so and move on - a hotfix release may not have
+had one.
+
+Then merge. Confirm before the first push - this updates a shared branch.
 
 ```bash
 git checkout main-v18
@@ -138,6 +159,8 @@ Resolve conflicts as:
 
 - `version.json` - keep the **higher** version (Phase 4 overwrites it anyway).
 - `CHANGELOG.md` - keep **both** sets of entries, newest version first.
+- `release-manifest.json` - delete it. It must not exist on dev. Phase 2 should
+  have removed it already, so seeing it here means that step was skipped.
 - Anything else - ask the user.
 
 Never force-push. If a push is rejected, pull and retry the merge.
@@ -156,8 +179,10 @@ For each released package, increment the patch in `src/<PackageName>/version.jso
 Always bump the **patch**, whatever kind of bump the release itself was. This is
 mechanical - it only exists to keep preview builds sorting above the release.
 
-Set the same value in that package's `Client/public/umbraco-package.json` where it
-has one. CI does not stamp that source manifest, so skipping it lets the two drift.
+**Do not touch `Client/public/umbraco-package.json`.** It is a fixed `1.0.0`
+placeholder; the real version is stamped into the `wwwroot` copy by
+`UpdatePackageManifestVersion` on CI builds. Bumping it here used to be required,
+and it is what made three packages look changed to release detection.
 
 > **Changelog gate.** CI fails a version bump with no matching changelog entry. A
 > bare patch bump has no user-facing content, so add a short entry:
@@ -168,6 +193,10 @@ has one. CI does not stamp that source manifest, so skipping it lets the two dri
 >
 > * Development version bump after the 7.1.0 release.
 > ```
+> Keep the literal word `Unreleased` and the `### Internal` bullet.
+> `/release-management` finalises this same entry at the next release, replacing
+> the word with a date and dropping the bullet - it does not add a second heading.
+>
 > Then confirm with:
 > ```bash
 > pwsh -File .azure-pipelines/scripts/validate-changelogs.ps1
@@ -176,7 +205,7 @@ has one. CI does not stamp that source manifest, so skipping it lets the two dri
 Commit and push:
 
 ```bash
-git add src/*/version.json src/*/CHANGELOG.md src/*/Client/public/umbraco-package.json
+git add src/*/version.json src/*/CHANGELOG.md
 git commit -m "chore(release): Bump dev versions after release 2026.08.1
 
 - Umbraco.Cms.Integrations.Search.Algolia: 7.1.0 -> 7.1.1

--- a/.claude/skills/release-management/SKILL.md
+++ b/.claude/skills/release-management/SKILL.md
@@ -16,23 +16,23 @@ machinery removed, because this repo is shaped differently:
   dependency cascade, no forced bumps, no `Directory.Packages.props` range
   updates and no npm peer-dependency syncing. If you find yourself reasoning
   about "which other packages does this one affect", stop - the answer is none.
-- **No release manifest.** `release-manifest.json` does not exist here. On a
-  release branch, CI treats a package as shipping when its `version.json`
-  differs from `main-v<N>` - the bump itself is the declaration. Nothing to
-  maintain, and no `include`/`exclude` lists to keep in sync.
-- **Check `main-v<N>` actually has `version.json` before cutting.** The
-  comparison is `git show main-v<N>:src/<pkg>/version.json`. When that file is
-  absent, `detect-changes.ps1` treats the package as new to the line and
-  force-includes it - so a release branch cut against a `main-v<N>` that
-  predates NBGV selects *every* package and produces clean-versioned artifacts
-  for all of them, including versions already published to NuGet. Verify with:
+- **`release-manifest.json` decides what ships.** As in `Umbraco.AI`. It is
+  required on `v<N>/release/*`, optional on `v<N>/hotfix/*`, and its `include`
+  list replaces the build set outright. Change detection in
+  `detect-changes.ps1` is only a cross-check: anything it finds changed must
+  appear in `include` or `exclude`, or CI fails.
 
-  ```bash
-  git ls-tree -r --name-only origin/main-v18 | grep -c version.json
-  ```
-
-  A `0` means stop: the build/versioning work has not been merged to
-  `main-v<N>` yet, and that must happen before any release branch is cut.
+  A bumped `version.json` is **not** the declaration, and selecting on it does
+  not work. `/post-release-cleanup` bumps each released package's patch on dev,
+  which used to make every previously-released package look like it was shipping
+  on every subsequent release branch, while a package whose version had never
+  moved could not be selected at all.
+- **The version is usually already bumped.** Because of that same dev patch bump,
+  the target version is often already in `version.json` when you cut the branch.
+  Check before editing.
+- **`Client/public/umbraco-package.json` is a fixed `1.0.0` placeholder.** Do not
+  bump it. The real version is stamped into the `wwwroot` copy by CI. Editing it
+  would also make the package look changed to release detection.
 - **Tags are `release/<slug>-<version>`**, e.g. `release/search-algolia-7.1.0` -
   not `Product@Version`. Note the branch is `v18/release/<date>` while tags are
   `release/<slug>-<version>`; they live in different ref namespaces and do not
@@ -47,10 +47,12 @@ machinery removed, because this repo is shaped differently:
 2. Recommend a version bump per package from the commit history.
 3. Confirm with the user.
 4. **Cut the release branch** - before any file changes.
-5. Update each package's `version.json`.
-6. Write each package's `CHANGELOG.md` entry.
-7. Review the changelogs for noise and completeness.
-8. Validate, commit and push the release branch.
+5. Write `release-manifest.json`.
+6. Update each package's `version.json`, where it is not already correct.
+7. Finalise each package's `CHANGELOG.md` entry.
+8. Review the changelogs for noise and completeness.
+9. Validate, dry-run the selection, commit and push the release branch.
+10. Report what remains manual.
 
 ---
 
@@ -204,7 +206,7 @@ one; start at `1` if the month has none. Confirm the name with the user, then:
 git checkout -b v18/release/2026.08.1
 ```
 
-The matching date tag `2026.08.1` is created at release time, in Phase 9, next to
+The matching date tag `2026.08.1` is created at release time, in Phase 10, next to
 the per-package tags. It is what lets the next release pick the right number, so
 skipping it breaks the sequence for whoever releases next - on either line.
 
@@ -213,30 +215,73 @@ For an urgent fix on top of an already-released state, cut
 
 ---
 
-## Phase 5: Update the version files
+## Phase 5: Write the release manifest
 
-Now on the release branch. For each confirmed package:
+Still on the release branch, before touching versions. **This is what CI treats as
+the decision on what ships** - see `Get-ManifestSelection` in
+`.azure-pipelines/scripts/detect-changes.ps1`. Change detection there is only a
+cross-check.
 
-1. Edit the `version` field of `src/<PackageName>/version.json`. Leave every other
-   property untouched. This is the one that actually drives the build.
-2. Set the same value in `src/<PackageName>/Client/public/umbraco-package.json`, if
-   the package has one (Analytics.Cookiebot does not). CI does **not** stamp this
-   source manifest, so it drifts if skipped - `Search.Algolia` shipped as `7.0.1`
-   with `7.0.0` still recorded here.
+```bash
+pwsh -File scripts/generate-release-manifest.ps1 \
+  -Include Umbraco.Cms.Integrations.Crm.Dynamics
+```
+
+Full package folder names. The script validates them against the real package
+list, so a typo fails here rather than in CI, and it is case-insensitive so you do
+not have to remember that git tracks `...URLInspectionTool`.
+
+If any package has substantive changes but is deliberately **not** shipping, name
+it in `-Exclude`. CI fails when a changed package appears in neither list - that
+guard is the whole point, so do not work around it by dropping the package from
+the release without saying so.
+
+`release-manifest.json` is **required** on `v<N>/release/*` and optional on
+`v<N>/hotfix/*`. `/post-release-cleanup` deletes it before merging back, so it
+never reaches `main-v<N>` or `v<N>/dev`.
+
+---
+
+## Phase 6: Update the version files
+
+For each confirmed package, edit the `version` field of
+`src/<PackageName>/version.json`. Leave every other property untouched. This is
+the only file that drives the version.
+
+**Usually it is already correct.** `/post-release-cleanup` bumps each released
+package's patch on dev after a release, so the target version is often already
+sitting there. Check before editing.
 
 Do **not** touch:
 
 - the `.csproj` (it has no `<Version>` - the version comes from `version.json`)
-- `wwwroot/umbraco-package.json` - the `UpdatePackageManifestVersion` target in the
-  root `Directory.Build.targets` stamps it on CI builds, so any value committed here
-  is overwritten anyway
+- `Client/public/umbraco-package.json` - it is a fixed `1.0.0` placeholder and is
+  no longer maintained by hand. The real version is stamped into the `wwwroot`
+  copy by `UpdatePackageManifestVersion` in the root `Directory.Build.targets`.
+  Bumping it would also make the package look changed to release detection.
+- `wwwroot/umbraco-package.json` - build output, stamped on CI builds, so any
+  value committed here is overwritten anyway
 
 ---
 
-## Phase 6: Write the changelog entry
+## Phase 7: Write the changelog entry
 
-For each package, add a new entry at the top of `src/<PackageName>/CHANGELOG.md`,
-below the header block, in [Keep a Changelog][kac] format:
+**Check for an existing entry first.** `/post-release-cleanup` leaves an
+`## [<version>] - Unreleased` heading on dev for the version being worked on, so
+the entry for the version you are releasing usually already exists. **Finalise it
+- do not add a second one**, or the changelog ends up with two headings for the
+same version.
+
+Finalising means:
+
+- Replace `Unreleased` with today's real date. Get it with `date +%Y-%m-%d` - do
+  not guess.
+- Delete the `### Internal` / "Development version bump after the X release."
+  bullet. That is bookkeeping, not a released change.
+- Add the real bullets underneath.
+
+Only write a fresh entry when there is genuinely no heading for that version.
+Either way the result is one entry, in [Keep a Changelog][kac] format:
 
 ```markdown
 ## [7.1.0] - 2026-08-12
@@ -252,14 +297,13 @@ below the header block, in [Keep a Changelog][kac] format:
 
 Rules:
 
-- Use today's real date. Get it with `date +%Y-%m-%d` - do not guess.
 - Group by commit type, using the type as the heading (`feat`, `fix`, `perf`).
 - One bullet per user-facing change, taken from the commit subject.
 - A breaking change gets its own `### Breaking` section, listed first.
 
 ---
 
-## Phase 7: Review the changelogs
+## Phase 8: Review the changelogs
 
 Before committing, review each entry you just wrote.
 
@@ -301,19 +345,38 @@ Clean
 ---
 
 
-## Phase 8: Validate, commit and push the release branch
+## Phase 9: Validate, dry-run, commit and push the release branch
 
-Run the same check CI runs, so a failure surfaces here rather than in the pipeline:
+Run the same changelog check CI runs, so a failure surfaces here rather than in
+the pipeline:
 
 ```bash
 pwsh -File .azure-pipelines/scripts/validate-changelogs.ps1
 ```
 
-Confirm each bumped `version.json` has a matching changelog heading, then commit and
-push the release branch:
+**Then dry-run the selection.** There are no automated tests for the selection
+logic, so this is the only check that what ships is what you meant:
 
 ```bash
-git add src/*/version.json src/*/CHANGELOG.md src/*/Client/public/umbraco-package.json
+pwsh -File .azure-pipelines/scripts/detect-changes.ps1 \
+  -SourceBranch "refs/heads/v18/release/2026.08.1" \
+  -ReleaseCompareRef "origin/main-v18"
+```
+
+Read the `Build plan:` block and confirm the `BUILD` lines are exactly the
+packages you intend to publish. Watch for two things:
+
+- A `note: <package> has no substantive changes but is being released` line.
+  Legitimate for a package that has never shipped, suspicious otherwise.
+- A throw about a changed package missing from the manifest. Add it to `include`
+  or `exclude` - do not delete the guard.
+
+Show the user that block before pushing.
+
+Then commit and push:
+
+```bash
+git add release-manifest.json src/*/version.json src/*/CHANGELOG.md
 git commit -m "chore(release): Prepare release 2026.08.1
 
 - Umbraco.Cms.Integrations.Search.Algolia: 7.0.1 -> 7.1.0
@@ -322,6 +385,10 @@ git commit -m "chore(release): Prepare release 2026.08.1
 git push -u origin v18/release/2026.08.1
 ```
 
+`release-manifest.json` must be in the commit, or CI fails on the release branch.
+Do not add `src/*/Client/public/umbraco-package.json` - it is a placeholder now
+and a release does not touch it.
+
 Use the **release branch name** in the commit subject, not the package versions -
 one branch can carry several packages at different versions.
 
@@ -329,14 +396,12 @@ Pushing a new release branch is safe: it touches no shared branch, and nothing i
 published until a human promotes the artifact. `main-v18` and `v18/dev` are left
 untouched until `/post-release-cleanup` runs.
 
-CI will then build this branch and produce **clean-versioned** artifacts. Because
-the branch matches `publicReleaseRefSpec`, and because the pipeline selects the
-packages whose `version.json` differs from `main-v18`, only the packages you just
-bumped are built and packed.
+CI will then build this branch and produce **clean-versioned** artifacts, for
+exactly the packages named in the manifest's `include` list.
 
 ---
 
-## Phase 9: Report what remains manual
+## Phase 10: Report what remains manual
 
 ```
 Release branch v18/release/2026.08.1 pushed, carrying:
@@ -382,9 +447,11 @@ asks - those are outward-facing and irreversible.
   hotfix is cut from `main-v<N>`; confirm which the user means.
 - **A release branch for this month already exists** - it may be an in-flight
   release. Show it and ask whether to add to it or start the next number.
-- **`main-v<N>` has no `version.json` files** - stop. Cutting a release branch
-  in that state force-includes every package and builds clean-versioned
-  artifacts for versions already on NuGet. Say that the build/versioning work
-  has to reach `main-v<N>` first, and do not cut the branch.
+- **The dry-run throws about an unaccounted changed package** - a package has
+  substantive changes and is in neither `include` nor `exclude`. Decide which it
+  belongs in with the user and regenerate the manifest. Never silence the guard.
+- **The dry-run notes a package with no substantive changes** - fine for a
+  package that has never shipped, or when rebuilding an already merged-back
+  release branch. Otherwise it is probably in `include` by mistake.
 
 [kac]: https://keepachangelog.com/en/1.0.0/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file is for **navigation, structure, and release workflow**. Package-specif
 - **Stack:** .NET (net10.0 on the v17/v18 lines), Umbraco CMS as the host, per-package **TypeScript + Vite** backoffice client compiled into `wwwroot`, built/packed via **Azure Pipelines**.
 - **Not a single product:** there is no shared runtime library across packages — they are sibling projects that share only the repo, tooling, and release conventions. No package references another.
 
-> **v18 vs v17.** The v18 line has moved to central package management, per-package `version.json` (NBGV) and a single pipeline — described below. **The v17 line and legacy `main` still use the older manual process** (hand-edited `<Version>` in three files, one pipeline per package). Sections 3 and 4 flag where the two differ.
+> **v18, v17 and legacy `main`.** The v18 and v17 lines both use central package management, per-package `version.json` (NBGV) and a single pipeline — described below. Their two pipeline scripts differ only in a fallback line default, so a change to one ports mechanically to the other. **Only the legacy `main` branch still uses the older manual process** (hand-edited `<Version>` in three files, one pipeline per package). Sections 3 and 4 flag where they differ.
 
 ---
 
@@ -40,8 +40,8 @@ src/Umbraco.Cms.Integrations.<Area>.<Name>/
   CHANGELOG.md                         - Keep a Changelog format; required when bumping
   Client/                              - TypeScript + Vite source; an npm workspace of the
                                          root package.json (no per-package lockfile)
-    src/, public/umbraco-package.json  - backoffice manifest; SOURCE copy, carries a real
-                                         version, NOT stamped by CI - keep in step by hand
+    src/, public/umbraco-package.json  - backoffice manifest; SOURCE copy, version is a
+                                         fixed 1.0.0 placeholder - never hand-edit
   wwwroot/                             - COMPILED client assets - GITIGNORED, never committed
                                          (+ umbraco-package.json, copied by Vite, CI-stamped)
   readme.md, docs/, umbraco-marketplace-readme.md
@@ -118,15 +118,19 @@ Bump rule, from the commits affecting that package ([Conventional Commits][cc]):
 
 **Do not hand-edit:** the csproj (`<Version>` is gone) or `wwwroot/umbraco-package.json` — an `UpdatePackageManifestVersion` target in the root `Directory.Build.targets` stamps the latter on CI builds, so the committed value is always overwritten in the published package.
 
-**Do keep in step:** `Client/public/umbraco-package.json`. It is the source manifest the Vite build copies into `wwwroot`, and CI does **not** stamp it. Every package carries a real version there, so bump it alongside `version.json`. Its value never reaches the published package (the `wwwroot` copy is stamped after the copy — verified with the client build enabled), but drift is confusing: `Search.Algolia` sat at `7.0.0` while shipping as `7.0.1`.
+**Also do not hand-edit:** `Client/public/umbraco-package.json`. It is a fixed `1.0.0` placeholder in all 8 packages that have one (Cookiebot has no client), matching `Umbraco.AI`. The Vite build copies it into `wwwroot`, and `UpdatePackageManifestVersion` stamps the real version into that copy on CI builds, so the placeholder never reaches a published package.
 
-> Reducing this to a true placeholder (as `Umbraco.AI` does) would remove the last hand-maintained version file. Not done here — it would touch all 9 packages and was out of scope.
+> It used to carry a real version, bumped by hand in both release skills. That churn is what made three packages look changed to release detection, so the placeholder is now load-bearing, not just tidiness. One consequence: a **local** `dotnet pack` has `ContinuousIntegrationBuild` false, so the stamp does not run and a locally built `.nupkg` carries `1.0.0`. Local packs are not published.
 
 On `main-v18` a build produces a clean version (`7.0.2`). On any other branch NBGV appends a preview suffix (`7.0.2--preview.4.gabc1234`), which sorts **below** the release — hence the post-release patch bump on dev.
 
 Each package keeps **one major per Umbraco major** (see the table in section 2).
 
-### Versioning — v17 line and legacy `main` (manual)
+### Versioning — v17 line
+
+**Same as v18.** The v17 line was migrated too: it carries `version.json`, per-package `CHANGELOG.md`, central package management and the same two pipeline scripts. The only difference between the lines' copies of `detect-changes.ps1` and `validate-changelogs.ps1` is the fallback line default (`v17` versus `v18`), so a change to either script ports mechanically.
+
+### Versioning — legacy `main` (manual)
 
 Still the old way: pipelines pack with `versioningScheme: off` and the version comes from the csproj `<Version>`. Bumping means editing **all three**:
 
@@ -152,19 +156,24 @@ The pipeline **only builds + packs the `.nupkg` + SBOM as artifacts** — it doe
 
 > **`N` counts release events across the whole repo, not per line.** It is derived from the `YYYY.MM.N` date tags, which carry no line prefix, so v17 and v18 releases share one sequence — `v18/release/2026.08.1` is followed by `v17/release/2026.08.2`, not a second `.1`. This matches `Umbraco.Automate` and `Umbraco.AI`, which both derive it from those tags. Two tag shapes are in play and cannot collide: `release/<slug>-<version>` identifies a published package, `YYYY.MM.N` identifies the release event and is what the next release counts from.
 
-**No release manifest.** Unlike `Umbraco.AI`, there is no `release-manifest.json`. On a release branch, CI treats a package as shipping when its `version.json` differs from `main-v<N>` — the bump itself is the declaration.
+**`release-manifest.json` declares what ships**, as in `Umbraco.AI`. Two layers, because "what changed" and "what are we publishing" are different questions:
 
-> **`main-v<N>` must carry `version.json` before the first release branch is cut.** The comparison is `git show main-v<N>:src/<pkg>/version.json`; when that file does not exist there, `detect-changes.ps1` treats the package as new to the line and force-includes it. Until this work is merged, `main-v18` has no `version.json` for any package, so a release branch cut now selects **all nine** regardless of what was bumped — and because a release branch drops the preview suffix, it would hand you nine clean-versioned `.nupkg` files at versions several of which are already on NuGet (`Search.Algolia` `7.0.1`, for one). Merge to `main-v<N>` first and this never arises; it is a one-time condition, not an ongoing hazard.
+1. **Detection proposes.** For each package, `detect-changes.ps1` diffs `merge-base(main-v<N>, HEAD)..HEAD` scoped to the package folder, ignoring `version.json` and `CHANGELOG.md` as release bookkeeping.
+2. **The manifest decides.** Required on `v<N>/release/*`, optional on `v<N>/hotfix/*`. Its `include` list replaces the build set outright, so a package with no changes still ships if listed. Anything detection found changed must appear in `include` or `exclude`, or the build fails — that guard is how you cannot silently forget a package.
+
+Written by `scripts/generate-release-manifest.ps1`, which validates names against the real package list. Deleted by `/post-release-cleanup` before the merge back, so it never lands on `main-v<N>` or `v<N>/dev`.
+
+> **Selecting on "`version.json` differs from `main-v<N>`" was tried first and does not work.** `/post-release-cleanup` bumps each released package's patch on dev, so that test reported every previously-released package as shipping on every subsequent release branch — five packages selected when one had changed. In the other direction, `SEO.GoogleSearchConsole.URLInspectionTool` reads the same version on dev and `main-v18` and has no release tag on either line, so it could never be selected at all. The manifest's `include` is what makes it releasable.
 
 Two skills cover the repeatable parts:
 
-- **`/release-management`** — detect changed packages, recommend the bump, **cut the release branch**, update `version.json`, write the `CHANGELOG.md` entry, push.
-- **`/post-release-cleanup`** — merge the release branch into `main-v<N>` **and** back into `v<N>/dev`, bump each released package's patch on dev, optionally delete the branch.
+- **`/release-management`** — detect changed packages, recommend the bump, **cut the release branch**, write `release-manifest.json`, update `version.json`, finalise the `CHANGELOG.md` entry, dry-run the selection, push.
+- **`/post-release-cleanup`** — delete `release-manifest.json`, merge the release branch into `main-v<N>` **and** back into `v<N>/dev`, bump each released package's patch on dev, optionally delete the branch.
 - **`/changelog-management`** — changelog work on its own: preview what a package would release, backfill a missing entry, or fix a `validate-changelogs.ps1` failure. Unlike `Umbraco.Automate`/`Umbraco.AI` there is no generation script behind it; entries come from reading `git log`.
 
 Full sequence:
 
-1. `/release-management` on `v<N>/dev` — cuts `v<N>/release/YYYY.MM.N`, bumps, changelogs, pushes.
+1. `/release-management` on `v<N>/dev` — cuts `v<N>/release/YYYY.MM.N`, writes the manifest, bumps, changelogs, dry-runs, pushes.
 2. Pipeline builds the release branch. **Verify the artifact is clean-versioned** before continuing.
 3. **Promote** it to NuGet (separate step).
 4. Create an annotated tag `release/<slug>-<version>` (e.g. `release/crm-hubspot-9.0.1`).
@@ -184,14 +193,22 @@ Full sequence:
 `azure-pipelines.yml` covers the whole repo in two stages:
 
 1. **DetectChanges** — `.azure-pipelines/scripts/detect-changes.ps1` discovers packages (a `src/` folder with both a `.csproj` and a `version.json`), then selects what to build based on the branch:
-   - **`v18/release/*` / `v18/hotfix/*`** — selects packages whose `version.json` differs from `main-v18`, i.e. those with a new version to publish. Throws if nothing was bumped.
+   - **`v18/release/*` / `v18/hotfix/*`** — diffs each package against `merge-base(main-v18, HEAD)`, ignoring `version.json` and `CHANGELOG.md`, then `release-manifest.json` decides. See the two-layer model in section 3. The manifest is required on `release/*` and optional on `hotfix/*`.
    - **PRs** — diffs against the merge-base with the target branch.
    - **`main-v18` / `v18/dev`** — diffs against `HEAD~1`.
    - **feature branches** — diffs against the merge-base with `v18/dev`.
 
    A `Directory.Packages.props` change is traced to only the packages referencing the packages whose versions moved. Then `validate-changelogs.ps1` runs (on a release branch it compares against `main-v18`, so every bump the release carries is checked).
 
-   > Package paths are resolved to the casing **git** tracks, not the casing on disk. `git show <ref>:<path>` is case-sensitive even on Windows, and this repo has `...GoogleSearchConsole.URLInspectionTool` in the index while working copies have appeared with `...UrlInspectionTool` on disk. Without this, that package was reported as brand new and force-included in every release.
+   > Package paths are resolved to the casing **git** tracks, not the casing on disk. `git show <ref>:<path>` and `git diff -- <path>` are case-sensitive even on Windows, and this repo has `...GoogleSearchConsole.URLInspectionTool` in the index while working copies have appeared with `...UrlInspectionTool` on disk. Manifest name lookup is deliberately case-insensitive for the same reason, resolving to the git-tracked name.
+
+   > **There are no tests for this logic**, matching `Umbraco.AI`. The safety net is a dry-run, which `/release-management` runs before pushing a release branch:
+   > ```bash
+   > pwsh -File .azure-pipelines/scripts/detect-changes.ps1 \
+   >   -SourceBranch "refs/heads/v18/release/2026.08.3" \
+   >   -ReleaseCompareRef "origin/main-v18"
+   > ```
+   > `-ReleaseCompareRef` exists for this. It is load-bearing, not a debug flag.
 
 2. **Test** — `dotnet test` over `tests/**/*Tests.csproj`, publishing `.trx` results and Cobertura coverage. **`Pack` depends on this stage**, so a failing test blocks packing and therefore blocks any promotion to NuGet.
 
@@ -200,7 +217,11 @@ Full sequence:
 
 Adding a package needs **no pipeline change** — give it a `version.json`.
 
-### v17 line and legacy `main`
+### v17 line
+
+Same single-pipeline arrangement as v18, with the same two scripts. Keep the two in step: a fix to `detect-changes.ps1` or `validate-changelogs.ps1` on one line belongs on the other.
+
+### Legacy `main`
 
 Still **one pipeline per package**, path-filtered to `src/<project>/**`.
 
@@ -219,7 +240,7 @@ Still **one pipeline per package**, path-filtered to `src/<project>/**`.
 
 ## Quick Reference
 
-**Key directories:** `/src` (packages) · `/tests` · `/examples` (test sites) · `/.azure-pipelines` (scripts + templates, v18)
+**Key directories:** `/src` (packages) · `/tests` · `/examples` (test sites) · `/.azure-pipelines` (CI scripts + templates, v18) · `/scripts` (release tooling — kept out of `.azure-pipelines/` because a change there rebuilds every package)
 
 **Branches:** `main-v18` / `v18/dev` (Umbraco 18) · `main-v17` / `v17/dev` (Umbraco 17) · `main` (legacy v10–13)
 
@@ -228,8 +249,13 @@ Still **one pipeline per package**, path-filtered to `src/<project>/**`.
 **Release tag convention:** `release/<slug>-<version>` (annotated), e.g. `release/search-algolia-7.0.1`
 
 **Bump a version:**
-- **v18 line** → edit `src/<package>/version.json` only, and add a `CHANGELOG.md` entry
-- **v17 / legacy** → edit 3 files: csproj `<Version>`, `Client/public/umbraco-package.json`, `wwwroot/umbraco-package.json`
+- **v18 line** → edit `src/<package>/version.json` only, and add a `CHANGELOG.md` entry. Never `Client/public/umbraco-package.json` — it is a fixed `1.0.0` placeholder
+- **legacy `main`** → edit 3 files: csproj `<Version>`, `Client/public/umbraco-package.json`, `wwwroot/umbraco-package.json`
+
+**Declare a release** (v18 line, on the release branch):
+```bash
+pwsh -File scripts/generate-release-manifest.ps1 -Include Umbraco.Cms.Integrations.Crm.Dynamics
+```
 
 **First run after a clone (v18 line) — `wwwroot` is not in git:**
 ```bash

--- a/scripts/generate-release-manifest.ps1
+++ b/scripts/generate-release-manifest.ps1
@@ -1,0 +1,256 @@
+# ============================================================================
+# Umbraco.Cms.Integrations release manifest generator
+# ============================================================================
+# Writes release-manifest.json at the repo root, naming the packages a release
+# branch will publish.
+#
+# The manifest is what CI treats as the decision on a release branch - see
+# Get-ManifestSelection in .azure-pipelines/scripts/detect-changes.ps1. Change
+# detection there is only a cross-check.
+#
+# This lives in scripts/ rather than .azure-pipelines/scripts/ on purpose: it is
+# a release-manager tool, not a CI script, and detect-changes.ps1 treats any
+# change under .azure-pipelines/ as affecting every package - so keeping it here
+# means editing it does not trigger a full nine-package rebuild.
+#
+# Usage:
+#   pwsh -File scripts/generate-release-manifest.ps1 -Include Umbraco.Cms.Integrations.Crm.Dynamics
+#   pwsh -File scripts/generate-release-manifest.ps1 -Include A,B -Exclude C
+#   pwsh -File scripts/generate-release-manifest.ps1            # numbered menu
+# ============================================================================
+
+param(
+    # Packages to publish. Omit for an interactive numbered menu.
+    [string[]]$Include = @(),
+
+    # Packages that changed but are deliberately not being published. CI fails if
+    # a changed package appears in neither list, so this is how you say "yes, I
+    # know, not this one".
+    [string[]]$Exclude = @(),
+
+    [string]$RootPath = (Get-Location).Path
+)
+
+$ErrorActionPreference = "Stop"
+
+function Split-NameList {
+    <#
+    .SYNOPSIS
+    Flattens a name list, splitting any comma-separated element.
+
+    .DESCRIPTION
+    `pwsh -File` mangles list arguments two different ways, and both are forms a
+    human will reasonably type:
+
+      -Include A,B,C      arrives as the single string "A,B,C" - the binder does
+                          not split it for a [string[]] parameter under -File
+      -Include "A","B"    the CALLING shell joins the array with spaces before
+                          handing it to a native command, so it arrives as "A B"
+
+    That second form also arrives with the quote characters still attached, so they
+    are stripped too.
+
+    Splitting on commas and whitespace, then stripping quotes, makes every form
+    work. Safe because no package folder name contains any of those characters.
+    #>
+    param([string[]]$Values)
+
+    $out = @()
+    foreach ($value in $Values) {
+        foreach ($part in ($value -split '[,\s]+')) {
+            $trimmed = $part.Trim().Trim('"', "'")
+            if ($trimmed) { $out += $trimmed }
+        }
+    }
+
+    return $out
+}
+
+function Get-PackableProducts {
+    <#
+    .SYNOPSIS
+    Discovers packable packages under src/, keyed by the casing git tracks.
+
+    .DESCRIPTION
+    Same rule as detect-changes.ps1: a folder qualifies when it contains both
+    <Name>.csproj and version.json. The two must agree, or a manifest that
+    validates here would fail in CI.
+
+    Names are resolved to the casing git tracks, not the casing on disk. git is
+    case-sensitive when looking paths up inside tree objects even on Windows, and
+    this repo has ...SEO.GoogleSearchConsole.URLInspectionTool in the index while
+    working copies have appeared as ...UrlInspectionTool.
+    #>
+    param([string]$RootPath)
+
+    $srcPath = Join-Path $RootPath "src"
+    if (-not (Test-Path $srcPath)) {
+        throw "No src/ folder under $RootPath - run this from the repo root."
+    }
+
+    $gitCasing = @{}
+    git -C $RootPath ls-tree -d --name-only HEAD src/ 2>$null |
+        Where-Object { $_ -is [string] } |
+        ForEach-Object {
+            $gitName = Split-Path $_ -Leaf
+            $gitCasing[$gitName.ToLower()] = $gitName
+        }
+
+    $products = @()
+
+    Get-ChildItem -Path $srcPath -Directory |
+        Where-Object { $_.Name -like "Umbraco.Cms.Integrations.*" } |
+        ForEach-Object {
+            $name = $_.Name
+            if (-not (Test-Path (Join-Path $_.FullName "$name.csproj"))) { return }
+            if (-not (Test-Path (Join-Path $_.FullName "version.json"))) { return }
+
+            $gitName = $gitCasing[$name.ToLower()]
+            if (-not $gitName) { $gitName = $name }
+
+            $version = (Get-Content (Join-Path $_.FullName "version.json") -Raw |
+                ConvertFrom-Json).version
+
+            $products += [pscustomobject]@{ Name = $gitName; Version = $version }
+        }
+
+    if ($products.Count -eq 0) {
+        throw "No packable packages found under $srcPath - check that version.json files are present."
+    }
+
+    return @($products | Sort-Object Name)
+}
+
+function Resolve-ProductNames {
+    <#
+    .SYNOPSIS
+    Validates supplied names against the discovered packages and returns the
+    canonical git-tracked names.
+
+    .DESCRIPTION
+    Case-insensitive on purpose - see the casing note in Get-PackableProducts. A
+    name that does not resolve is a terminating error, so a typo fails here
+    rather than in CI.
+    #>
+    param(
+        [string[]]$Names,
+        [string]$ListName,
+        [object[]]$Products
+    )
+
+    $byLower = @{}
+    $Products | ForEach-Object { $byLower[$_.Name.ToLower()] = $_.Name }
+
+    $resolved = @()
+    foreach ($item in $Names) {
+        if ([string]::IsNullOrWhiteSpace($item)) {
+            throw "'$ListName' contains an empty package name."
+        }
+
+        $key = $byLower[$item.Trim().ToLower()]
+        if (-not $key) {
+            $known = ($Products | ForEach-Object { $_.Name }) -join "`n  "
+            throw "'$ListName' names a package that does not exist or is not packable: $item`n`nKnown packages:`n  $known"
+        }
+
+        if ($resolved -notcontains $key) { $resolved += $key }
+    }
+
+    return $resolved
+}
+
+function Read-ProductSelection {
+    <#
+    .SYNOPSIS
+    Numbered menu fallback when -Include was not supplied.
+    #>
+    param([object[]]$Products)
+
+    Write-Host ""
+    Write-Host "Select the packages this release publishes:" -ForegroundColor Cyan
+    Write-Host ""
+
+    for ($i = 0; $i -lt $Products.Count; $i++) {
+        Write-Host ("  {0,2}. {1}  ({2})" -f ($i + 1), $Products[$i].Name, $Products[$i].Version)
+    }
+
+    Write-Host ""
+    $answer = Read-Host "Numbers, comma or space separated (e.g. 1,4)"
+
+    $picked = @()
+    foreach ($token in ($answer -split '[,\s]+' | Where-Object { $_ })) {
+        $n = 0
+        if (-not [int]::TryParse($token, [ref]$n) -or $n -lt 1 -or $n -gt $Products.Count) {
+            throw "'$token' is not one of the listed numbers."
+        }
+        $name = $Products[$n - 1].Name
+        if ($picked -notcontains $name) { $picked += $name }
+    }
+
+    if ($picked.Count -eq 0) {
+        throw "Nothing selected - a release branch exists to publish something."
+    }
+
+    return $picked
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+Write-Host "======================================="
+Write-Host "Umbraco.Cms.Integrations release manifest"
+Write-Host "======================================="
+
+$products = Get-PackableProducts -RootPath $RootPath
+
+$Include = Split-NameList -Values $Include
+$Exclude = Split-NameList -Values $Exclude
+
+$includeNames = if ($Include.Count -gt 0) {
+    Resolve-ProductNames -Names $Include -ListName "Include" -Products $products
+}
+else {
+    Read-ProductSelection -Products $products
+}
+
+$excludeNames = @()
+if ($Exclude.Count -gt 0) {
+    $excludeNames = Resolve-ProductNames -Names $Exclude -ListName "Exclude" -Products $products
+}
+
+$overlap = @($includeNames | Where-Object { $excludeNames -contains $_ })
+if ($overlap.Count -gt 0) {
+    throw "The same package cannot be in both Include and Exclude: $($overlap -join ', ')"
+}
+
+# Written as an ordered hashtable so include always precedes exclude in the file.
+$manifest = [ordered]@{
+    include = @($includeNames | Sort-Object)
+    exclude = @($excludeNames | Sort-Object)
+}
+
+$manifestPath = Join-Path $RootPath "release-manifest.json"
+$json = ($manifest | ConvertTo-Json -Depth 3) + "`n"
+Set-Content -Path $manifestPath -Value $json -NoNewline -Encoding utf8
+
+Write-Host ""
+Write-Host "Wrote $manifestPath" -ForegroundColor Green
+Write-Host ""
+Write-Host "Publishing:" -ForegroundColor Cyan
+foreach ($name in $manifest.include) {
+    $version = ($products | Where-Object { $_.Name -eq $name }).Version
+    Write-Host "  $name  $version" -ForegroundColor Green
+}
+
+if ($manifest.exclude.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Deliberately not publishing:" -ForegroundColor DarkYellow
+    foreach ($name in $manifest.exclude) {
+        Write-Host "  $name" -ForegroundColor DarkYellow
+    }
+}
+
+Write-Host ""
+Write-Host "Commit this file on the release branch. /post-release-cleanup deletes it" -ForegroundColor Gray
+Write-Host "before merging back, so it never reaches main-v<N> or v<N>/dev." -ForegroundColor Gray

--- a/src/Umbraco.Cms.Integrations.Automation.Zapier/Client/public/umbraco-package.json
+++ b/src/Umbraco.Cms.Integrations.Automation.Zapier/Client/public/umbraco-package.json
@@ -1,7 +1,7 @@
 {
     "id": "Umbraco.Cms.Integrations.Automation.Zapier",
     "name": "Umbraco CMS Integrations: Automation - Zapier",
-    "version": "6.0.0",
+    "version": "1.0.0",
     "extensions": [
       {
         "name": "Umbraco EntryPoint",

--- a/src/Umbraco.Cms.Integrations.Commerce.Shopify/Client/public/umbraco-package.json
+++ b/src/Umbraco.Cms.Integrations.Commerce.Shopify/Client/public/umbraco-package.json
@@ -1,7 +1,7 @@
 {
     "id": "Umbraco.Cms.Integrations.Commerce.Shopify",
     "name": "Umbraco CMS Integrations: Commerce - Shopify",
-    "version": "6.0.2",
+    "version": "1.0.0",
     "extensions": [
       {
         "name": "Umbraco EntryPoint",

--- a/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/Client/public/umbraco-package.json
+++ b/src/Umbraco.Cms.Integrations.Crm.ActiveCampaign/Client/public/umbraco-package.json
@@ -1,7 +1,7 @@
 ﻿{
   "id": "Umbraco.Cms.Integrations.Crm.ActiveCampaign",
   "name": "Umbraco CMS Integrations: CRM - ActiveCampaign",
-  "version": "7.0.1",
+  "version": "1.0.0",
   "extensions": [
     {
       "name": "Umbraco EntryPoint",

--- a/src/Umbraco.Cms.Integrations.Crm.Dynamics/Client/public/umbraco-package.json
+++ b/src/Umbraco.Cms.Integrations.Crm.Dynamics/Client/public/umbraco-package.json
@@ -1,7 +1,7 @@
 {
     "id": "Umbraco.Cms.Integrations.Crm.Dynamics",
     "name": "Umbraco CMS Integrations: Crm - Dynamics",
-    "version": "6.0.3",
+    "version": "1.0.0",
     "extensions": [
       {
         "name": "Umbraco EntryPoint",

--- a/src/Umbraco.Cms.Integrations.Crm.Hubspot/Client/public/umbraco-package.json
+++ b/src/Umbraco.Cms.Integrations.Crm.Hubspot/Client/public/umbraco-package.json
@@ -1,7 +1,7 @@
 ﻿{
     "id": "Umbraco.Cms.Integrations.Crm.HubSpot",
     "name": "Umbraco CMS Integrations: CRM - HubSpot",
-    "version": "9.0.3",
+    "version": "1.0.0",
     "extensions": [
       {
         "name": "Umbraco EntryPoint",

--- a/src/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.URLInspectionTool/Client/public/umbraco-package.json
+++ b/src/Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.URLInspectionTool/Client/public/umbraco-package.json
@@ -1,7 +1,7 @@
 {
     "id": "Umbraco.Cms.Integrations.SEO.GoogleSearchConsole.URLInspectionTool",
     "name": "Umbraco CMS Integrations: SEO - GoogleSearchConsole.URLInspectionTool",
-    "version": "3.0.0",
+    "version": "1.0.0",
     "extensions": [
       {
         "name": "Umbraco EntryPoint",

--- a/src/Umbraco.Cms.Integrations.SEO.Semrush/Client/public/umbraco-package.json
+++ b/src/Umbraco.Cms.Integrations.SEO.Semrush/Client/public/umbraco-package.json
@@ -1,7 +1,7 @@
 {
     "id": "Umbraco.Cms.Integrations.SEO.Semrush",
     "name": "Umbraco CMS Integrations: SEO - Semrush",
-    "version": "5.0.0",
+    "version": "1.0.0",
     "extensions": [
       {
         "name": "Umbraco EntryPoint",

--- a/src/Umbraco.Cms.Integrations.Search.Algolia/Client/public/umbraco-package.json
+++ b/src/Umbraco.Cms.Integrations.Search.Algolia/Client/public/umbraco-package.json
@@ -1,7 +1,7 @@
 ﻿{
   "id": "Umbraco.Cms.Integrations.Search.Algolia",
   "name": "Umbraco CMS Integrations: Search - Algolia",
-  "version": "7.0.3",
+  "version": "1.0.0",
   "extensions": [
     {
       "name": "Umbraco EntryPoint",


### PR DESCRIPTION
Release branches picked packages by comparing each `version.json` against `main-v18`. That test conflates "this is the version being worked on" with "publish this version", and it fails in both directions.

## The problem, measured

**Too many.** `/post-release-cleanup` bumps each released package's patch on dev so preview builds sort above the release. That bump makes the package differ from `main-v18` until it next ships, so every release branch cut afterwards selects it again with nothing in it. Cutting one today:

```
* Analytics.Cookiebot 4.0.0 -> 4.0.1     no changes
* Commerce.Shopify    6.0.1 -> 6.0.2     no changes
* Crm.Dynamics        6.0.2 -> 6.0.3     one fix
* Crm.Hubspot         9.0.2 -> 9.0.3     no changes
* Search.Algolia      7.0.2 -> 7.0.3     no changes
```

Five selected, one real. Nothing is auto-published, so this was noise rather than danger, but it repeated on every release and would have grown.

**Too few.** `SEO.GoogleSearchConsole.URLInspectionTool` reads `3.0.0` on both `v18/dev` and `main-v18`, and has no `release/*` tag on either line. Because the versions match, it could never be selected. It was unreleasable without first inventing a version bump.

## The change

The two-layer arrangement `Umbraco.AI` already uses:

1. **Detection proposes.** Each package is diffed against `merge-base(main-v18, HEAD)`, ignoring `version.json` and `CHANGELOG.md` as release bookkeeping.
2. **`release-manifest.json` decides.** Required on `release/*`, optional on `hotfix/*`. Its `include` list replaces the build set outright, so a package with no changes still ships if listed. Anything detection found changed must appear in `include` or `exclude`, or the build fails.

That second guard is the important half: forgetting a changed package is the expensive mistake, so it is the loud one.

`scripts/generate-release-manifest.ps1` writes the file and validates names against the real package list, so a typo fails at generation rather than in CI. It lives in a new `scripts/` folder rather than `.azure-pipelines/scripts/` because `detect-changes.ps1` treats any change under the latter as affecting every package.

## Why not per-package tags, like AI

AI runs `git describe --match "<Product>@*"`. Our tag slugs are not consistent enough: both `release/crm-activecampaign-*` and `release/crm-active-campaign-*` exist, as do both `release/shopify-1.2.0` and `release/commerce-shopify-*`. `main-v18` is the documented last-released state and `/post-release-cleanup` always merges into it, so it carries the same information with no slug guessing.

## The placeholder change

`Client/public/umbraco-package.json` is now a fixed `1.0.0` in all eight packages that have one (Cookiebot has no client), matching `Umbraco.AI`. Both release skills used to bump it by hand, and that churn is exactly what made Shopify, Hubspot and Algolia read as changed under the new filter. `CLAUDE.md` already recommended this and recorded it as out of scope; it is in scope now because the churn is load-bearing.

Verified rather than assumed: I set a built `wwwroot` copy to `1.0.0`, built with `-p:ContinuousIntegrationBuild=true`, and `UpdatePackageManifestVersion` rewrote it to `6.0.3--preview.5.g763e519`. A local `dotnet pack` does not stamp, so a locally built `.nupkg` carries `1.0.0`. Local packs are not published, so that is accepted and documented.

## Verification

**No tests, matching AI**, which has none for either pipeline script. The safety net is a dry-run through `-ReleaseCompareRef`, which `/release-management` now runs before pushing a release branch. That parameter changes from a debug convenience to load-bearing, and says so in its comment.

Checks I ran against the real repo:

| Case | Result |
|---|---|
| Bookkeeping-only diff (Cookiebot) | `release bookkeeping only (2 file(s)) - not a change`, skipped |
| Release branch, no manifest | throws |
| Empty `include` | throws |
| Unknown package name | throws |
| Changed package in neither list | throws |
| `exclude` accounts for changed packages | passes, logs the exclusions |
| `include` names a package with no changes | ships, logs `note: ... has no substantive changes but is being released` |
| `v18/dev` build with a manifest present | manifest ignored, same selection as before |
| Generator arg forms `A,B` / `"A","B"` / single / `-Exclude` list | all resolve |
| Generator with a typo | exits 1, writes nothing |

One real bug surfaced while testing: `pwsh -File script.ps1 -Include A,B,C` delivers `"A,B,C"` as a single string, and `-Include "A","B"` arrives space-joined with the quotes attached. Both are forms a human would type, and both are what the skill documents, so the generator now normalises them.

## Also in here

Docs that had drifted, found while updating them:

- `CLAUDE.md` said the v17 line still uses the manual three-file versioning process and one pipeline per package. It does not; v17 was migrated and its two scripts differ from v18's only in a fallback line default.
- `/release-management` Phase 6 told you to add a new changelog entry dated today, but dev already carries an `## [<version>] - Unreleased` heading for that same version from the dev bump, so following it produced a duplicate. It now finalises the existing entry.

## Follow-ups, not in this PR

- Port to `v17/dev`. Mechanical, once this is proven.
- `SEO.GoogleSearchConsole.URLInspectionTool` has no release tag on either line, while its `main-v17` changelog reads `## [2.0.0] - 2026-08-10` as though it shipped. Worth checking whether it is actually on NuGet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
