### PR TITLE
chore(skills): Move tagging and GitHub releases into post-release-cleanup

### DIFF
--- a/.claude/skills/post-release-cleanup/SKILL.md
+++ b/.claude/skills/post-release-cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: post-release-cleanup
-description: Closes out a release - merges the release branch into main-v<N> and back into v<N>/dev, bumps the patch of each released package on dev so preview builds sort above the release, and optionally deletes the release branch. Use after a release has been published to NuGet and tagged.
+description: Closes out a release - verifies the packages are on NuGet, creates the release tags and GitHub releases, merges the release branch into main-v<N> and back into v<N>/dev, bumps the patch of each released package on dev so preview builds sort above the release, and optionally deletes the release branch. Use once a release has been promoted to NuGet.
 ---
 
 # Post-Release Cleanup
@@ -14,17 +14,37 @@ You close out a release for **Umbraco.Cms.Integrations**.
                                release-manifest.json, bumps version.json
                                + CHANGELOG there, pushes the branch
 2. CI builds the release branch -> clean 7.1.0 artifacts
-3. Promote to NuGet           (manual)
-4. Tag release/<slug>-<version> (manual)
-5. GitHub release per tag     (manual)
-6. THIS SKILL                 - delete the manifest, merge back, bump dev
+3. Promote to NuGet           (manual - the only manual step left)
+4. THIS SKILL                 - verify on NuGet, tag, GitHub releases,
+                               delete the manifest, merge back, bump dev
                                patches, tidy up
 ```
 
 ## When to run
 
-Only after the packages are **actually on NuGet and tagged**. Merging into
-`main-v<N>` before that would leave it claiming a release that does not exist.
+Once the packages have been **promoted to NuGet**. That is the only thing this
+skill cannot do for you.
+
+Tagging and the GitHub releases used to be manual steps between
+`/release-management` and this skill, and they were the steps that got forgotten:
+the v18 `.0.0` tags went missing entirely and had to be backfilled, and it
+happened again on `2026.08.3`/`2026.08.4`, where the cleanup had to stop because
+no tags existed. A step owned by neither skill is a step nobody does, so this
+skill owns it now.
+
+They cannot move into `/release-management` instead. That runs before CI has built
+anything, so there is nothing published for a tag to point at, and a tag created
+then becomes a lie if the artifact is never promoted.
+
+## What identifies the release
+
+`release-manifest.json`, on the release branch. Its `include` list is what
+`/release-management` declared and what CI actually built and packed, so it is the
+same answer CI used - no inference, no slug guessing.
+
+This skill reads it in Phase 1 and deletes it in Phase 5, so it is available at
+exactly the moment it is needed. **Do not** work out what shipped by reading tags:
+this skill creates those, so at Phase 1 they do not exist yet.
 
 ## Why the version bump matters
 
@@ -43,11 +63,11 @@ Adapted from `Umbraco.AI`'s skill of the same name, minus:
 - **Git hooks.** `Umbraco.AI` deletes `release-manifest.json` with a `.githooks`
   post-merge hook. This repo has no `.githooks` directory, and adding one would
   mean every contributor has to set `core.hooksPath` or the cleanup silently stops
-  happening. Phase 2 does it explicitly instead.
+  happening. Phase 5 does it explicitly instead.
 
 ---
 
-## Phase 1: Identify the release
+## Phase 1: Identify the release, and verify it shipped
 
 ```bash
 git branch --show-current
@@ -58,61 +78,192 @@ Expect to be on `v<N>/release/*` or `v<N>/hotfix/*`. If not, ask the user which
 release branch to process. Derive the line from the branch name
 (`v18/release/2026.08.1` → line `v18`, released branch `main-v18`, dev `v18/dev`).
 
-Find the release tags on this branch that are not yet on `main-v<N>`:
+Read what shipped from the manifest:
 
 ```bash
 release_branch=$(git branch --show-current)
-
-for tag in $(git tag --list 'release/*'); do
-  tag_commit=$(git rev-parse "$tag^{commit}")
-  if git merge-base --is-ancestor "$tag_commit" HEAD 2>/dev/null && \
-     ! git merge-base --is-ancestor "$tag_commit" origin/main-v18 2>/dev/null; then
-    echo "$tag"
-  fi
-done
+cat release-manifest.json
 ```
 
-Map each tag back to its package folder by matching against the discovered packages,
-not by reversing the slug rules - the historical slugs are inconsistent (both
-`crm-activecampaign` and `crm-active-campaign` exist).
+Every name in `include` is a released package. For each one, read the version from
+`src/<PackageName>/version.json` on this branch. That pairing - name plus version -
+is what everything below is built from.
 
-Cross-check the tag versions against the `version.json` values on this branch. If
-they disagree, stop and report it: it means what was tagged is not what this branch
-builds.
-
-Confirm with the user:
+**If `release-manifest.json` is missing**, stop and offer choices. Do not guess:
 
 ```
-Release branch: v18/release/2026.08.1
-Tagged and published:
-  - Search.Algolia 7.1.0  (release/search-algolia-7.1.0)
-  - Crm.Hubspot    9.0.2  (release/crm-hubspot-9.0.2)
+No release-manifest.json on v18/release/2026.08.1.
 
-Plan:
-  1. merge v18/release/2026.08.1 -> main-v18
-  2. merge v18/release/2026.08.1 -> v18/dev
-  3. bump on v18/dev: 7.1.0 -> 7.1.1, 9.0.2 -> 9.0.3
-
-Proceed? [Yes / Cancel]
-```
-
-**If no tags are found**, stop and offer choices - do not proceed:
-
-```
-No release tags found on this branch that are missing from main-v18.
-
-That usually means the packages have not been tagged (or pushed) yet.
+It is required on a release branch, so either this cleanup has already run
+(Phase 5 deletes it), or the branch was cut by hand.
 
 Options:
-  - Tag and publish first, then re-run
   - Tell me which packages and versions were released, and I will use those
-  - Merge only, and skip the version bump
+  - Check whether the tags already exist, and skip to the merges
+  - Cancel
+```
+
+**Verify each package is actually on NuGet.** This is the check that has failed
+before, so make it against the registry rather than against memory:
+
+```bash
+pkg=Umbraco.Cms.Integrations.Crm.Dynamics
+version=6.0.3
+
+curl -s "https://api.nuget.org/v3-flatcontainer/$(echo "$pkg" | tr 'A-Z' 'a-z')/index.json" \
+  | grep -q "\"$version\"" && echo "on NuGet" || echo "NOT VISIBLE"
+```
+
+The package id is the folder name, lowercased - the NuGet API needs lower case.
+
+A hit means it is published. A miss means one of two things, and they need
+different responses:
+
+- **Not promoted yet.** Stop. Tagging and merging now would leave `main-v<N>`
+  claiming a release that does not exist.
+- **Promoted, but NuGet has not indexed it yet.** Indexing lags behind an upload
+  by minutes, and all three of NuGet's indexes (flat container, registration,
+  search) can lag together - that happened on `2026.08.3`.
+
+So report the miss, say plainly that absence here is not proof it was never
+pushed, and let the user decide:
+
+```
+Not visible on NuGet:
+  - Umbraco.Cms.Integrations.Crm.Dynamics 6.0.3
+
+NuGet indexing lags an upload by a few minutes, so this may be timing rather
+than a missing promotion.
+
+Options:
+  - Wait and re-check
+  - I have confirmed it is pushed, proceed anyway
   - Cancel
 ```
 
 ---
 
-## Phase 2: Delete the manifest, then merge into main-v&lt;N&gt;
+## Phase 2: Confirm the whole plan
+
+**One gate, covering everything outward-facing.** Show exactly what will be
+created and changed, then use **AskUserQuestion**. Nothing below this point runs
+until the user says yes.
+
+```
+Release branch: v18/release/2026.08.1
+On NuGet:       Search.Algolia 7.1.0, Crm.Hubspot 9.0.2
+
+Will create and push these tags:
+  release/search-algolia-7.1.0
+  release/crm-hubspot-9.0.2
+  2026.08.1                      (release event, repo-wide)
+
+Will create these GitHub releases:
+  release/search-algolia-7.1.0   body from Search.Algolia CHANGELOG [7.1.0]
+  release/crm-hubspot-9.0.2      body from Crm.Hubspot CHANGELOG [9.0.2]
+  (the date tag gets no GitHub release - it is bookkeeping)
+
+Then:
+  1. delete release-manifest.json on the release branch
+  2. merge v18/release/2026.08.1 -> main-v18
+  3. merge v18/release/2026.08.1 -> v18/dev
+  4. bump on v18/dev: 7.1.0 -> 7.1.1, 9.0.2 -> 9.0.3
+
+Proceed?
+```
+
+Tags and GitHub releases are public and awkward to retract, which is why they get
+a gate. It is one gate rather than several: the decision is the same decision, and
+splitting it just interrupts a flow the user has already agreed to.
+
+---
+
+## Phase 3: Create and push the tags
+
+Two shapes, both annotated, both on the release branch.
+
+**One per released package**, `release/<slug>-<version>`. The slug is the package
+name minus the `Umbraco.Cms.Integrations.` prefix, lowercased, dots to hyphens.
+
+> Slugs in the existing history are **not** consistent - both
+> `release/crm-activecampaign-*` and `release/crm-active-campaign-*` exist, and
+> Shopify has both `release/shopify-1.2.0` and `release/commerce-shopify-*`. For a
+> new tag, derive it by the rule above. When you need to find an *existing* tag,
+> use `git tag --list` rather than deriving it.
+
+**One for the release event**, `YYYY.MM.N`, matching the release branch name. It is
+repo-wide and carries no line prefix. It is how the *next* release works out its
+number, on either line, so skipping it breaks the sequence for whoever releases
+next.
+
+```bash
+git checkout "$release_branch"
+
+git tag -a release/search-algolia-7.1.0 -m "Search.Algolia 7.1.0"
+git tag -a release/crm-hubspot-9.0.2    -m "Crm.Hubspot 9.0.2"
+git tag -a 2026.08.1                    -m "Release 2026.08.1"
+
+git push origin release/search-algolia-7.1.0 release/crm-hubspot-9.0.2 2026.08.1
+```
+
+Then confirm each tag points at the release branch tip:
+
+```bash
+for t in release/search-algolia-7.1.0 release/crm-hubspot-9.0.2 2026.08.1; do
+  echo "$t -> $(git rev-parse --short "$t^{commit}")"
+done
+```
+
+The two tag shapes answer different questions and cannot collide: one starts with
+`release/`, the other with a digit.
+
+---
+
+## Phase 4: Create the GitHub releases
+
+One per **package** tag. The date tag gets none - it is bookkeeping, not a thing
+anyone downloads.
+
+Title is the tag name. Body is that version's changelog section, so the release
+notes and the changelog cannot drift apart:
+
+```bash
+pkg=src/Umbraco.Cms.Integrations.Search.Algolia
+version=7.1.0
+tag=release/search-algolia-7.1.0
+
+# Everything between this version's heading and the next one. index(...) == 1
+# anchors to the start of the line without needing regex escaping for the
+# brackets, which is what makes this survive a version like 7.1.0.
+awk -v v="$version" '
+  index($0, "## [" v "]") == 1 { found=1; next }
+  found && index($0, "## [") == 1 { exit }
+  found { print }
+' "$pkg/CHANGELOG.md" > /tmp/notes.md
+
+test -s /tmp/notes.md || { echo "No changelog body for $version - stopping"; exit 1; }
+
+gh release create "$tag" \
+  --repo umbraco/Umbraco.Cms.Integrations \
+  --title "$tag" \
+  --notes-file /tmp/notes.md \
+  --verify-tag
+```
+
+Two guards worth keeping:
+
+- `test -s` catches an empty body. That means the changelog heading and
+  `version.json` disagree, which is a real problem - publishing an empty release
+  note hides it. Stop and show the user the changelog.
+- `--verify-tag` makes `gh` fail rather than create the tag itself, so a typo
+  cannot produce a release pointing at a tag nobody reviewed.
+
+Add PR links to the body where they help. Do not try to derive them from commit
+messages; ask the user if it is not obvious.
+
+---
+
+## Phase 5: Delete the manifest, then merge into main-v&lt;N&gt;
 
 `release-manifest.json` belongs only to the release branch. It is **required** on
 `v<N>/release/*`, so leaving it in place would carry it onto `main-v<N>` and
@@ -144,7 +295,7 @@ git push origin main-v18
 
 ---
 
-## Phase 3: Merge into v&lt;N&gt;/dev
+## Phase 6: Merge into v&lt;N&gt;/dev
 
 The release branch carries the bumped `version.json` and changelog entries, so dev
 needs them too or the next release starts from stale versions.
@@ -157,17 +308,17 @@ git merge "$release_branch" --no-ff -m "Merge $release_branch into v18/dev"
 
 Resolve conflicts as:
 
-- `version.json` - keep the **higher** version (Phase 4 overwrites it anyway).
+- `version.json` - keep the **higher** version (Phase 7 overwrites it anyway).
 - `CHANGELOG.md` - keep **both** sets of entries, newest version first.
 - `release-manifest.json` - delete it. It must not exist on dev. Phase 2 should
-  have removed it already, so seeing it here means that step was skipped.
+  have removed it already, so seeing it here means Phase 5 was skipped.
 - Anything else - ask the user.
 
 Never force-push. If a push is rejected, pull and retry the merge.
 
 ---
 
-## Phase 4: Bump the patch on dev
+## Phase 7: Bump the patch on dev
 
 For each released package, increment the patch in `src/<PackageName>/version.json`:
 
@@ -215,7 +366,7 @@ git push origin v18/dev
 
 ---
 
-## Phase 5: Delete the release branch (optional)
+## Phase 8: Delete the release branch (optional)
 
 Ask the user:
 
@@ -239,10 +390,19 @@ signal one of the merges did not land - investigate rather than forcing it.
 
 ---
 
-## Phase 6: Summary
+## Phase 9: Summary
 
 ```
 Post-release cleanup complete.
+
+Tagged:
+  release/search-algolia-7.1.0
+  release/crm-hubspot-9.0.2
+  2026.08.1
+
+GitHub releases:
+  release/search-algolia-7.1.0
+  release/crm-hubspot-9.0.2
 
 Merged:
   v18/release/2026.08.1 -> main-v18
@@ -257,14 +417,34 @@ Release branch: deleted / kept
 Preview builds on v18/dev now sort above the released versions.
 ```
 
-Then flag anything still outstanding - most often a missing GitHub release for one
-of the tags.
+Verify rather than assert. Before reporting done:
+
+```bash
+git ls-remote --tags origin | grep -E "2026.08.1|search-algolia-7.1.0"
+gh release list --repo umbraco/Umbraco.Cms.Integrations --limit 5
+
+for b in origin/main-v18 origin/v18/dev; do
+  git cat-file -e "$b:release-manifest.json" 2>/dev/null \
+    && echo "LEAKED on $b" || echo "clean: $b"
+done
+```
+
+Then flag anything still outstanding.
 
 ## Error handling
 
-- **Merge conflicts** - resolve per the rules in Phase 3, ask about the rest.
+- **`release-manifest.json` missing** - stop and offer the Phase 1 choices. It is
+  the only thing that says what shipped.
+- **A package is not visible on NuGet** - offer the Phase 1 choices. Indexing lag
+  and a missing promotion look identical from here, so do not decide for the user.
+- **A tag already exists** - the cleanup may have partly run. Check what it points
+  at. If it is the release branch tip, skip creating it and carry on; if not, stop.
+  Never move an existing tag.
+- **`gh release create` fails on `--verify-tag`** - the tag was not pushed. Push
+  Phase 3's tags first, then retry.
+- **The changelog body comes out empty** - the heading and `version.json` disagree.
+  Stop and show the user; do not publish an empty release note.
+- **Merge conflicts** - resolve per the rules in Phase 6, ask about the rest.
 - **Push rejected** - the branch is protected, or someone else pushed. Pull and
   retry. Never force-push.
-- **Tag versions disagree with `version.json`** - stop. What was published may not
-  match this branch; that needs a human decision.
 - **Malformed `version.json`** - show the user and ask; do not guess.

--- a/.claude/skills/release-management/SKILL.md
+++ b/.claude/skills/release-management/SKILL.md
@@ -401,41 +401,37 @@ exactly the packages named in the manifest's `include` list.
 
 ---
 
-## Phase 10: Report what remains manual
+## Phase 10: Report what happens next
 
 ```
 Release branch v18/release/2026.08.1 pushed, carrying:
   - Search.Algolia 7.0.1 -> 7.1.0
   - Crm.Hubspot    9.0.1 -> 9.0.2
 
-main-v18 and v18/dev are untouched so far.
+main-v18 and v18/dev are untouched.
 
-Still to do by hand:
+Next:
   1. Wait for CI on v18/release/2026.08.1. Confirm the artifacts are
      clean-versioned (7.1.0, NOT 7.1.0--preview.N) before going further.
-  2. Promote each artifact to NuGet.
-  3. Tag each released package, on the release branch:
-       git tag -a release/search-algolia-7.1.0 -m "Search.Algolia 7.1.0"
-       git tag -a release/crm-hubspot-9.0.2    -m "Crm.Hubspot 9.0.2"
-  4. Tag the release event itself, on the same branch:
-       git tag -a 2026.08.1 -m "Release 2026.08.1"
-     This one is repo-wide and carries no line prefix. It is how the NEXT
-     release works out its number, on either line - skip it and the sequence
-     breaks.
-       git push origin --tags
-  5. Create a GitHub release per PACKAGE tag, titled with the tag, linking the
-     PRs. The date tag is bookkeeping and gets no GitHub release.
-  6. Run /post-release-cleanup to merge the release branch into main-v18
-     and v18/dev, and bump the dev patch versions.
+  2. Promote each artifact to NuGet. This is the one step no skill does.
+  3. Run /post-release-cleanup on this branch. It verifies the packages are
+     on NuGet, creates the tags and the GitHub releases, deletes the manifest,
+     merges into main-v18 and v18/dev, and bumps the dev patches.
 ```
+
+**Do not tag, and do not create GitHub releases here.** They belong to
+`/post-release-cleanup`, and the reason is timing, not squeamishness: at this point
+CI has not built anything, so nothing is published for a tag to point at. A tag
+created now becomes a lie the moment someone decides not to promote the artifact.
+
+That also means **do not** offer to tag as a convenience if the user asks "what's
+left" - point them at `/post-release-cleanup` instead, so the tag, the GitHub
+release and the merge-back all happen from one place with one confirmation.
 
 > The two tag shapes answer different questions. `release/<slug>-<version>` is
 > "which commit is this published package", one per package. `YYYY.MM.N` is "which
 > commits went out together", one per release branch. They share the tag namespace
 > but cannot collide: one starts with `release/`, the other with a digit.
-
-Do not promote, tag, or create GitHub releases yourself unless the user explicitly
-asks - those are outward-facing and irreversible.
 
 ## Error handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,22 +167,24 @@ Written by `scripts/generate-release-manifest.ps1`, which validates names agains
 
 Two skills cover the repeatable parts:
 
-- **`/release-management`** — detect changed packages, recommend the bump, **cut the release branch**, write `release-manifest.json`, update `version.json`, finalise the `CHANGELOG.md` entry, dry-run the selection, push.
-- **`/post-release-cleanup`** — delete `release-manifest.json`, merge the release branch into `main-v<N>` **and** back into `v<N>/dev`, bump each released package's patch on dev, optionally delete the branch.
+- **`/release-management`** — detect changed packages, recommend the bump, **cut the release branch**, write `release-manifest.json`, update `version.json`, finalise the `CHANGELOG.md` entry, dry-run the selection, push. It does **not** tag.
+- **`/post-release-cleanup`** — verify each package is on NuGet, create the **tags and GitHub releases**, delete `release-manifest.json`, merge the release branch into `main-v<N>` **and** back into `v<N>/dev`, bump each released package's patch on dev, optionally delete the branch.
 - **`/changelog-management`** — changelog work on its own: preview what a package would release, backfill a missing entry, or fix a `validate-changelogs.ps1` failure. Unlike `Umbraco.Automate`/`Umbraco.AI` there is no generation script behind it; entries come from reading `git log`.
 
 Full sequence:
 
 1. `/release-management` on `v<N>/dev` — cuts `v<N>/release/YYYY.MM.N`, writes the manifest, bumps, changelogs, dry-runs, pushes.
 2. Pipeline builds the release branch. **Verify the artifact is clean-versioned** before continuing.
-3. **Promote** it to NuGet (separate step).
-4. Create an annotated tag `release/<slug>-<version>` (e.g. `release/crm-hubspot-9.0.1`).
-5. Create a GitHub release (title = tag name), linking the relevant PRs.
-6. `/post-release-cleanup` — merges back into both branches and bumps dev.
+3. **Promote** it to NuGet. **This is the only manual step.**
+4. `/post-release-cleanup` on the release branch — verifies NuGet, tags, GitHub releases, merges back into both branches, bumps dev.
 
-> Tagging/releasing is easy to forget — the v18 `.0.0` tags were missing entirely and had to be backfilled. Always do steps 3–5 after promoting.
+> **Tagging and GitHub releases used to be manual steps 4 and 5, and they are the steps that got skipped.** The v18 `.0.0` tags went missing entirely and had to be backfilled; it happened again on `2026.08.3`/`2026.08.4`, where the cleanup had to stop because no tags existed. They belonged to neither skill, so nobody did them. `/post-release-cleanup` owns them now, behind one confirmation.
 >
-> Tag slugs are **not** perfectly consistent in the existing history (both `crm-activecampaign` and `crm-active-campaign` exist; Shopify has both `shopify-1.2.0` and `commerce-shopify-*`). Confirm a real tag with `git tag --list` rather than deriving the slug.
+> They cannot live in `/release-management` instead: that runs before CI has built anything, so nothing is published for a tag to point at, and a tag created then is a lie if the artifact is never promoted. `/post-release-cleanup` already requires the packages to be on NuGet, which is exactly when tagging becomes true.
+>
+> `release-manifest.json` is what tells the cleanup what shipped — the same declaration CI built from. The cleanup reads it, then deletes it.
+>
+> Tag slugs are **not** perfectly consistent in the existing history (both `crm-activecampaign` and `crm-active-campaign` exist; Shopify has both `shopify-1.2.0` and `commerce-shopify-*`). Derive the slug for a *new* tag; use `git tag --list` to find an *existing* one.
 
 ---
 


### PR DESCRIPTION
Tagging and GitHub release creation sat in the gap between `/release-management` and `/post-release-cleanup` as manual steps. Owned by neither skill, they are the steps that got skipped.

## Evidence, not a hunch

- `CLAUDE.md` already recorded it: the v18 `.0.0` tags went missing entirely and had to be backfilled.
- It happened again on `2026.08.3` and `2026.08.4`. The cleanup had to stop mid-flow because no tags existed, and the tags were created by hand afterwards.

Twice is a pattern. A step owned by neither skill is a step nobody does.

## Why post-release-cleanup and not release-management

`/release-management` runs **before** CI has built anything. A `release/<slug>-<version>` tag asserts "this commit is the published package". At that point nothing is published, and if the artifact is later not promoted, the tag is a lie you have to delete. The skill said so at line 437, and that reasoning still holds.

`/post-release-cleanup` already required the packages to be on NuGet. That is exactly the moment a tag becomes true. So the work moves there, not earlier.

## What identifies the release now

`release-manifest.json`, read from the release branch.

This had to change: the skill previously read tags to work out what shipped, and it now *creates* those tags, so they do not exist when it starts. The manifest is a better source anyway — it is the same declaration CI built and packed from, so the two cannot disagree.

The skill reads it in Phase 1 and deletes it in Phase 5, so it is available at exactly the right moment.

## New shape

| Phase | What |
|---|---|
| 1 | Read the manifest, then verify each version against the NuGet flat-container index |
| 2 | **One** confirmation covering every outward-facing action |
| 3 | Create and push the package tags plus the `YYYY.MM.N` date tag |
| 4 | `gh release create` per package tag, body from that version's changelog section |
| 5–9 | The previous phases, renumbered |

One gate rather than several: it is the same decision, and splitting it interrupts a flow the user already agreed to.

## The NuGet check is deliberately soft

It queries the registry rather than trusting memory, because that is the check that failed. But a miss is ambiguous: NuGet indexing lags an upload by minutes, and on `2026.08.3` all three of its indexes (flat container, registration, search) lagged together.

So the skill reports the miss, states plainly that absence is not proof nothing was pushed, and offers wait / proceed / cancel. It does not decide for you.

## Release notes come from the changelog

The body is extracted between the version's heading and the next one, so release notes and changelog cannot drift.

I tested the extraction against the real `Crm.Dynamics` changelog before writing it down. It returns the `6.0.3` section correctly, and returns **zero bytes** for a version with no entry. That empty case is guarded with `test -s`: an empty body means the changelog heading and `version.json` disagree, which is a real problem worth stopping for rather than publishing a blank release note.

`--verify-tag` is passed so `gh` fails rather than inventing a tag.

## Also in here

Two guards added to the error handling, both from things that could plausibly go wrong on a partial run:

- A tag that already exists: check what it points at, skip if it matches the branch tip, stop if not. Never move an existing tag.
- `gh release create` failing on `--verify-tag`: the tags were not pushed, so push Phase 3 first.

## Companion

v17: #345. Same change. The v17 PR also fixes a defect from my earlier backport — the dry-run code block in `CLAUDE.md` section 4 contained literal `\n` characters instead of line breaks. v18 was never affected; I checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
